### PR TITLE
Updates to CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All community members are expected to:
 
 Additionally, if you are a reporter or a member of the press:
 
-* you must have that information listed in your profile - documentation on how to do that is [available here](https://get.slack.help/hc/en-us/articles/204092246-Edit-your-profile)
+* you must have that information listed in your profile - documentation on how to do that is [available here](https://slack.com/help/articles/204092246-Edit-your-profile)
 * if you want to interview someone about something, you need to ask permission to interview them and inform them about where their comments may end up being published prior to the start of the interview. 
 
 Everyone is welcome to participate, and no judgement will be made on members of the greater Mac community who are not a part of the community.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome to the MacAdmins Slack Workspace
 
 ## Introduction
-This community is a complement to IRC channels, various MDM and package management user forums, Facebook groups, and the mailing lists. We seek to provide a safe, friendly community for Mac administrators, enthusiasts, and developers to interact with one another.
+The MacAdmins Slack Workspace is available as a means of collaboration for Apple device administrators, enthusiasts, and developers to interact with one another. It is meant to provide a safe, friendly community along side the already well established user forums, Facebook groups, and mailing lists to help facilitate more real-time collaboration when possible.
 
 We hope that you find the community to be enriching to your personal and professional lives, and above all else a place of camaraderie where our collective knowledge and differences are celebrated in a positive, welcoming environment.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to the MacAdmins Slack Team.
+# Welcome to the MacAdmins Slack Workspace
 
 ## Introduction
 This community is a complement to IRC channels, various MDM and package management user forums, Facebook groups, and the mailing lists. We seek to provide a safe, friendly community for Mac administrators, enthusiasts, and developers to interact with one another.
@@ -13,7 +13,7 @@ Thank you for following this code of conduct. We reserve the right to amend or c
 
 ## Code Of Conduct
 
-All are welcome to participate in the Slack team as long as the tenets of this Code of Conduct are adhered to.
+All are welcome to participate in the MacAdmins Slack Workspace as long as the tenets of this Code of Conduct are adhered to.
 
 ## Short Version:
 
@@ -37,7 +37,7 @@ Everyone is welcome to participate, and no judgement will be made on members of 
 
 ### Policies
 
-The MacAdmins Slack Team is dedicated to providing a harassment-free experience for everyone, regardless of (but not limited to): gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or preferred technological ecosystem.
+The MacAdmins Slack Workspace is dedicated to providing a harassment-free experience for everyone, regardless of (but not limited to): gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or preferred technological ecosystem.
 
 We do not tolerate harassment of Slack participants in any form. Sexual language and imagery is not appropriate for any venue. Slack participants violating these rules may be sanctioned or expelled from the MacAdmins Slack at the discretion of the Administrative Team.
 
@@ -78,7 +78,7 @@ The Administrative Team will handle all reports with discretion.
 
 If a party to a dispute is also a member of the Admin team, that person may have no role in the dispute resolution process except as a party; forfeiting any involvement in the enforcement and resolution process. It is the responsibility of that person to immediately inform the Admin team of the conflict. The only way a conflict of interest is applicable is when a person involved in the mediation/resolution process is also involved in the conflict. As members, we are entrusted to make decisions in the best interest of the community and set aside personal interest for the best interest of our community as a whole.
 
-If you have concerns regarding this Slack team, please feel free to contact the Administrative Team and we will work to understand and address them respectfully and with an appropriate level of privacy in the given situation.
+If you have concerns regarding this Slack workspace, please feel free to contact the Administrative Team and we will work to understand and address them respectfully and with an appropriate level of privacy in the given situation.
 
 ### Contributions and Modifications
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We hope that you find the community to be enriching to your personal and profess
 
 Thank you for following this code of conduct. We reserve the right to amend or change the code of conduct at any time and encourage you to periodically review these guidelines to ensure a safe environment for all.
 
--MacAdmins Slack Administrative Team
+-[MacAdmins Slack Workspace Administrative Team](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md)
 
 ---
 
@@ -70,13 +70,13 @@ We expect participants to follow these rules in all public and private channels 
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, and you feel comfortable speaking with the offender, please inform the offender that they have affected you negatively. Often, the offending behavior is unintentional, and the accidental offender and offended will resolve the incident by having that initial discussion. As a world-wide community, we recognize that there are inherent language barriers we must work together to overcome.
 
-The MacAdmins Slack Team recognizes that there are many reasons speaking directly to the offender may not be workable for you (all reasons are valid, we will never ask you to explain nor defend your reasons). If you don't feel comfortable speaking directly with the offender *for any reason*, please report violations directly to a member of the Administrative Team.
+The MacAdmins Slack Workspace Administrative Team recognizes that there are many reasons speaking directly to the offender may not be workable for you (all reasons are valid, we will never ask you to explain nor defend your reasons). If you don't feel comfortable speaking directly with the offender *for any reason*, please report violations directly to a member of the Administrative Team.
 
-[Current List of Administrators](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md).
+[Current List of MacAdmins Slack Workspace Administrators](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md).
 
 The Administrative Team will handle all reports with discretion.
 
-If a party to a dispute is also a member of the Admin team, that person may have no role in the dispute resolution process except as a party; forfeiting any involvement in the enforcement and resolution process. It is the responsibility of that person to immediately inform the Admin team of the conflict. The only way a conflict of interest is applicable is when a person involved in the mediation/resolution process is also involved in the conflict. As members, we are entrusted to make decisions in the best interest of the community and set aside personal interest for the best interest of our community as a whole.
+If a party to a dispute is also a member of the Administrative Team, that person may have no role in the dispute resolution process except as a party; forfeiting any involvement in the enforcement and resolution process. It is the responsibility of that person to immediately inform the Administrative Team of the conflict. The only way a conflict of interest is applicable is when a person involved in the mediation/resolution process is also involved in the conflict. As members, we are entrusted to make decisions in the best interest of the community and set aside personal interest for the best interest of our community as a whole.
 
 If you have concerns regarding this Slack workspace, please feel free to contact the Administrative Team and we will work to understand and address them respectfully and with an appropriate level of privacy in the given situation.
 


### PR DESCRIPTION
* Replaces references of "Slack team" to "Slack workspace"
* Removes reference to IRC channels
* Replaces 'Mac' with 'Apple'
* Generalizes references to other platforms

As always, open to feedback. This was just my first pass at attempting to update some wording to replace old references.