### PR TITLE
CoC proposed update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Welcome to the Mac Admins Slack.<!-- omit from toc -->
 
-The Mac Admins Slack is a global online community of people who manage Apple devices and services at large and small scales. The community is built around public and private channels focusing on managing Apple devices and services. While many channels are not focused specifically on managing Apple devices and services, all community participants are asked to act as professionals and must comply with the following Code of Conduct. The Mac Admins Slack Admin Team will enforce this code throughout all channels within the Slack.
+The Mac Admins Slack is a global online community of people who manage Apple devices and services at large and small scales. The community is built around public and private channels focusing on managing Apple devices and services. While many channels are not focused specifically on managing Apple devices and services, all community participants are asked to act as professionals and must comply with the following Code of Conduct(CoC).
+
+All principles in this CoC are important and enforceable. The Mac Admins Slack Admin Team will enforce this code throughout all channels within the Slack.
 
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to the Mac Admins Slack Team.<!-- omit from toc -->
+# Welcome to the Mac Admins Slack.<!-- omit from toc -->
 
 The Mac Admins Slack is a global online community of people who manage Apple devices and services at large and small scales. The community is built around public and private channels focusing on managing Apple devices and services. While many channels are not focused specifically on managing Apple devices and services, all community participants are asked to act as professionals and must comply with the following Code of Conduct. The Mac Admins Slack Admin Team will enforce this code throughout all channels within the Slack.
 
@@ -16,7 +16,7 @@ Thank you for following this code of conduct. We reserve the right to amend or c
 
 # Table of Contents
 
-- [Welcome to the Mac Admins Slack Team.](#welcome-to-the-macadmins-slack-team)
+- [Welcome to the Mac Admins Slack.](#welcome-to-the-Mac Admins-slack)
   - [Introduction](#introduction)
 - [Table of Contents](#table-of-contents)
 - [Code Of Conduct](#code-of-conduct)
@@ -39,7 +39,7 @@ Thank you for following this code of conduct. We reserve the right to amend or c
   - [Contributions and Modifications](#contributions-and-modifications)
 # Code Of Conduct
 
-All are welcome to participate in the Slack team as long as the tenets of this Code of Conduct are adhered to.
+All are welcome to participate in the Slack Workspace as long as the tenets of this Code of Conduct are adhered to.
 
 # Short Version:
 
@@ -84,7 +84,7 @@ Don't be a bystander, be a leader. Role model respectful behavior, but also help
 
 ## Harassment-free
 
-The MacAdmins Slack Team is dedicated to providing a harassment-free experience for everyone, regardless of (but not limited to): gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or preferred technological ecosystem.
+The Mac Admins Slack is dedicated to providing a harassment-free experience for everyone, regardless of (but not limited to): gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or preferred technological ecosystem.
 
 We do not tolerate harassment of Slack participants in any form. Sexual language and imagery is not appropriate for any venue. Slack participants violating these rules may be sanctioned or expelled from the Mac Admins Slack at the discretion of the Administrative Team.
 
@@ -115,7 +115,7 @@ For attribution of specific content found on this Slack on public channels, we a
 
 ## Read the Room
 
-Once onboard, you will likely find yourself in a popular channel with many members who sound like we've figured it out. We haven't. While advice on one channel might read definitive, it is one member's lessons interpretation and learning from their MacAdmin experience. While there is a diverse set of experiences within this community, we continue to learn at every level of expertise. The daily practice of being a MacAdmin is more art than science.
+Once onboard, you will likely find yourself in a popular channel with many members who sound like we've figured it out. We haven't. While advice on one channel might read definitive, it is one member's lessons interpretation and learning from their Mac Admin experience. While there is a diverse set of experiences within this community, we continue to learn at every level of expertise. The daily practice of being a Mac Admin is more art than science.
 
 This is a large community with many different humans populating hundreds of channels. Different channels have organically developed distinct personalities. Before posting in a channel with hundreds of members, we suggest you take the time to read the room. Specifically:
 
@@ -176,7 +176,7 @@ Additionally, if you are a reporter or a member of the press:
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, and you feel comfortable speaking with the offender, please inform the offender that they have affected you negatively. Often, the offending behavior is unintentional, and the accidental offender and offended will resolve the incident by having that initial discussion. As a world-wide community, we recognize that there are inherent language barriers we must work together to overcome.
 
-The Mac Admins Slack Team recognizes that there are many reasons speaking directly to the offender may not be workable for you (all reasons are valid, we will never ask you to explain nor defend your reasons). If you don't feel comfortable speaking directly with the offender *for any reason*, please report violations directly to a member of the Administrative Team.
+The Mac Admins Slack recognizes that there are many reasons speaking directly to the offender may not be workable for you (all reasons are valid, we will never ask you to explain nor defend your reasons). If you don't feel comfortable speaking directly with the offender *for any reason*, please report violations directly to a member of the Administrative Team.
 
 ## Administrators
 
@@ -186,7 +186,7 @@ The Administrative Team will handle all reports with discretion.
 
 If a party to a dispute is also a member of the Admin team, that person may have no role in the dispute resolution process except as a party; forfeiting any involvement in the enforcement and resolution process. It is the responsibility of that person to immediately inform the Admin team of the conflict. The only way a conflict of interest is applicable is when a person involved in the mediation/resolution process is also involved in the conflict. As members, we are entrusted to make decisions in the best interest of the community and set aside personal interest for the best interest of our community as a whole.
 
-If you have concerns regarding this Slack team, please feel free to contact the Administrative Team and we will work to understand and address them respectfully and with an appropriate level of privacy in the given situation.
+If you have concerns regarding this Slack, please feel free to contact the Administrative Team and we will work to understand and address them respectfully and with an appropriate level of privacy in the given situation.
 
 ## Administrator Information Access
 
@@ -198,7 +198,7 @@ As part of the role, Administrators have information not available to all users.
 
 Administrators do not have standing access to private channels unless they are members of that channel.
 
-Slack Workplace owners, of which only a limited set of the Admin Team are, have other tools (such as export and migration tools) that may provide access to private channels and DMs. As per the privacy section above, you should not presume anything you say here will remain private, so act accordingly.
+Slack Workspace owners, of which only a limited set of the Admin Team are, have other tools (such as export and migration tools) that may provide access to private channels and DMs. As per the privacy section above, you should not presume anything you say here will remain private, so act accordingly.
 
 As part of Code of Conduct investigations, Administrators may choose to access this information. Administrators may also request information from private channels from current channel members to investigate a Code of Conduct violation.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Welcome to the MacAdmins Slack Team.
+# Welcome to the Mac Admins Slack Team.<!-- omit from toc -->
+
+The Mac Admins Slack is a global online community of people who manage Apple devices and services at large and small scales. The community is built around public and private channels focusing on managing Apple devices and services. While many channels are not focused specifically on managing Apple devices and services, all community participants are asked to act as professionals and must comply with the following Code of Conduct. The Mac Admins Slack Admin Team will enforce this code throughout all channels within the Slack.
+
 
 ## Introduction
 This community is a complement to IRC channels, various MDM and package management user forums, Facebook groups, and the mailing lists. We seek to provide a safe, friendly community for Mac administrators, enthusiasts, and developers to interact with one another.
@@ -7,15 +10,42 @@ We hope that you find the community to be enriching to your personal and profess
 
 Thank you for following this code of conduct. We reserve the right to amend or change the code of conduct at any time and encourage you to periodically review these guidelines to ensure a safe environment for all.
 
--MacAdmins Slack Administrative Team
+-The Mac Admins Slack Administrative Team
 
----
 
-## Code Of Conduct
+
+# Table of Contents
+
+- [Welcome to the Mac Admins Slack Team.](#welcome-to-the-macadmins-slack-team)
+  - [Introduction](#introduction)
+- [Table of Contents](#table-of-contents)
+- [Code Of Conduct](#code-of-conduct)
+- [Short Version:](#short-version)
+- [Long Version:](#long-version)
+  - [Respect](#respect)
+  - [Harassment-free](#harassment-free)
+  - [Privacy](#privacy)
+  - [Read the Room](#read-the-room)
+  - [Direct Message Etiquette](#direct-message-etiquette)
+  - [Content Review Process](#content-review-process)
+  - [Resolve Peacefully](#resolve-peacefully)
+  - [Additional Consequences](#additional-consequences)
+  - [Vendor Guidelines](#vendor-guidelines)
+  - [Press Guidelines](#press-guidelines)
+  - [Reporting](#reporting)
+  - [Administrators](#administrators)
+  - [Administrator Information Access](#administrator-information-access)
+  - [Administrative Team Guidelines](#administrative-team-guidelines)
+  - [Contributions and Modifications](#contributions-and-modifications)
+# Code Of Conduct
 
 All are welcome to participate in the Slack team as long as the tenets of this Code of Conduct are adhered to.
 
-## Short Version:
+# Short Version:
+
+Be a valuable postive contributor to this community. 
+
+Be respectful of others, ask people to stop if you are bothered; respect privacy; understand this community is primarily not-for-profit, and attempt to resolve issues without Administrators, but if you can't resolve an issue, you can contact the Administrators. If you violate this Code of Conduct, it will be made clear to you, and you may be asked to leave the Rands Leadership Slack.
 
 All community members are expected to:
 
@@ -32,14 +62,31 @@ Additionally, if you are a reporter or a member of the press:
 Everyone is welcome to participate, and no judgement will be made on members of the greater Mac community who are not a part of the community.
 
 
-## Long Version:
+# Long Version:
 
+## Respect
 
-### Policies
+The Mac Admins Slack is an inclusive environment based on treating all individuals respectfully, regardless of gender or gender identity (including transgender status), sexual orientation, age, disability, nationality, ethnicity, religion (or lack thereof), political affiliation, or career path.
+
+We value respectful behavior above individual opinions.
+
+Respectful behavior includes but is not limited to:
+
+* Be considerate, kind, constructive, and helpful.
+* Avoid demeaning, discriminatory, harassing, hateful, or physically threatening behavior, speech, and imagery.
+* Due regard for the feelings, wishes, rights, and traditions of others.
+
+If you're unclear if a communication, action, or behavior is respectful, ask someone instead of assuming. No, really. Just ask the ([Administrators](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md)) publicly or privately. We'd rather hear from you than hear about something you said or did after the fact, and we are here to help.
+
+Don't be a bystander, be a leader. Role model respectful behavior, but also help to address disrespect when you see it within your community. 
+
+**Consequence**: Disrespectful behavior outside this community by active members may be considered a violation of this code of conduct at the Administrators' discretion.
+
+## Harassment-free
 
 The MacAdmins Slack Team is dedicated to providing a harassment-free experience for everyone, regardless of (but not limited to): gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or preferred technological ecosystem.
 
-We do not tolerate harassment of Slack participants in any form. Sexual language and imagery is not appropriate for any venue. Slack participants violating these rules may be sanctioned or expelled from the MacAdmins Slack at the discretion of the Administrative Team.
+We do not tolerate harassment of Slack participants in any form. Sexual language and imagery is not appropriate for any venue. Slack participants violating these rules may be sanctioned or expelled from the Mac Admins Slack at the discretion of the Administrative Team.
 
 Harassment includes, but is not limited to:
 
@@ -56,21 +103,82 @@ Harassment includes, but is not limited to:
 * Advocating for, or encouraging, any of the above behaviour
 * Direct messages or postings in channels/private groups of an overly sales/advertising/spam manner ([additional vendor guidelines](https://github.com/macadminsdotorg/codeofconduct/blob/master/Vendor_Guidelines.md))
 
+## Privacy
 
-### Enforcement
-Participants asked to stop any harassing behavior are expected to comply immediately
+Protect IP and legally-protected information. This community is not a public space. However, no one has signed a non-disclosure agreement ("NDA") to participate, and you should not presume anything you say here will remain private, so act accordingly.
 
-If a participant engages in harassing behaviour, the Administrative Team retain the right to take any actions to keep the event a welcoming environment for all participants, including warning the offender or expulsion of the offender from the MacAdmins Slack.
+If you want to disclose anything discussed here in a public channel publicly, use the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule) as the guideline ("participants are free to use the information received, but neither the identity nor the affiliation of the speaker(s), nor that of any other participant, may be revealed"). 
 
-The Administrative Team may take action to redress anything designed for, or with the clear impact of, disrupting the community or making the environment hostile for any participants.
+For attribution of specific content found on this Slack on public channels, we ask that you ask the originator of the content for permission. If you don't receive consent in a reasonable time, we ask that you credit the "Rands Leadership Slack."
+
+**Consequence**: Sharing content from private channels is discouraged without permission of the private channel. 
+
+## Read the Room
+
+Once onboard, you will likely find yourself in a popular channel with many members who sound like we've figured it out. We haven't. While advice on one channel might read definitive, it is one member's lessons interpretation and learning from their MacAdmin experience. While there is a diverse set of experiences within this community, we continue to learn at every level of expertise. The daily practice of being a MacAdmin is more art than science.
+
+This is a large community with many different humans populating hundreds of channels. Different channels have organically developed distinct personalities. Before posting in a channel with hundreds of members, we suggest you take the time to read the room. Specifically:
+
+* Read the last couple of days of messages.
+* Examine the channel topic for helpful tips.
+* Click on the channel details and read the about section to see how many members are present, what messages have already been pinned, and what files have been shared.
+* Use Slack's search feature. Your questions has problably already been discussed, or a least something similar. The results might give you the answer or help you frame your question better.
+
+**Consequence**: Posting the same message to multiple channels is spamming. Don't spam. 
+
+## Direct Message Etiquette
+
+A direct message ("DM") is a private message to one or more other members. Sending a DM to another member you don't know might be jarring for the receiver. Before sending a DM to a member you've never contacted, consider the following:
+
+* Is it obvious to the other member why I am contacting them privately? If not, should I provide context, such as a public post?
+* Could this message be considered unsolicited spam? If so, should you be sending it?
+
+**Consequence**: Unsolicited DMs are likely Code of Conduct violations, especially with a commercial flavor. 
+
+## Content Review Process
+
+The Administrators may come across or be notified of Mac Admins Slack content violating the Code of Conduct. In some situations, this may lead to an Administrator deleting the message (or messages) that violate the CoC. Messages most likely to be deleted are commercial solicitations, disrespectful messages to other members, or links to disturbing or distressing content without appropriate measures to warn of or hide the content (including image uploads and unfurls).
+
+Ideally, another Mac Admins Slack member notices this content and contacts the original poster, who then modifies or deletes the message so that it is no longer problematic. In this case, no further Administrator action is required. Suppose Administrator action is desired due to lack of response or any other reason. In that case, an Administrator will notify the original poster of the violation and the need to reword or remove the problematic message. The Administrator will also specify a time after which Administrator action will be taken to delete the content if it is not addressed. This time may be as little as a few minutes or as much as 24 hours.
+
+## Resolve Peacefully
+
+As a large online community, we believe peer-to-peer discussions, feedback, and corrections can help build a stronger, safer, more informed, and more welcoming community.
+
+If you see someone violating any part of this Code of Conduct, we urge you to respectfully dissuade them from such behavior using specifics from this document as guidelines. Expect that others in the community wish to help keep the community respectful and welcome your input.
+
+If you experience disrespectful behavior toward yourself or anyone else and feel unable or unwilling to respond or resolve it respectfully (for any reason), please immediately bring it to the attention of an Administrator. We want to hear from you about anything that you feel is disrespectful, threatening, or just something that could make someone feel distressed. We will listen and work to resolve the matter with your help promptly.
+
+Should you catch yourself behaving disrespectfully, or be confronted as such, listen intently, own up to your words and actions, and apologize accordingly. No one is perfect, and even well-intentioned people make mistakes. How you handle them and avoid repeating them in future matters. We are here to learn as leaders.
+
+## Additional Consequences
+
+If you cannot resolve a situation peacefully, please refer to our [Incident Process](https://github.com/macadminsdotorg/codeofconduct/blob/master/Incident_Process.md) and choose a course of action that suits the situation.
+
+Suppose the Administrators determine that a member is violating any part of this Code of Conduct. In that case, they may take any action they deem appropriate, up to and including expulsion and exclusion from the Rands Leadership Slack. 
+
+As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. This Code of Conduct documents everyday situations we've seen, but we can't foresee every situation. If in the Administrator's judgment, the best thing to do is to ask a disrespectful individual to leave, we will do so..
 
 We expect participants to follow these rules in all public and private channels (including direct messages).
 
-### Reporting
+## Vendor Guidelines
+
+See [Vendor Guidelines](https://github.com/macadminsdotorg/codeofconduct/blob/master/Vendor_Guidelines.md)
+
+## Press Guidelines
+
+Additionally, if you are a reporter or a member of the press:
+
+* you must have that information listed in your profile - documentation on how to do that is [available here](https://get.slack.help/hc/en-us/articles/204092246-Edit-your-profile)
+* if you want to interview someone about something, you need to ask permission to interview them and inform them about where their comments may end up being published prior to the start of the interview. 
+
+## Reporting
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, and you feel comfortable speaking with the offender, please inform the offender that they have affected you negatively. Often, the offending behavior is unintentional, and the accidental offender and offended will resolve the incident by having that initial discussion. As a world-wide community, we recognize that there are inherent language barriers we must work together to overcome.
 
-The MacAdmins Slack Team recognizes that there are many reasons speaking directly to the offender may not be workable for you (all reasons are valid, we will never ask you to explain nor defend your reasons). If you don't feel comfortable speaking directly with the offender *for any reason*, please report violations directly to a member of the Administrative Team.
+The Mac Admins Slack Team recognizes that there are many reasons speaking directly to the offender may not be workable for you (all reasons are valid, we will never ask you to explain nor defend your reasons). If you don't feel comfortable speaking directly with the offender *for any reason*, please report violations directly to a member of the Administrative Team.
+
+## Administrators
 
 [Current List of Administrators](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md).
 
@@ -80,6 +188,32 @@ If a party to a dispute is also a member of the Admin team, that person may have
 
 If you have concerns regarding this Slack team, please feel free to contact the Administrative Team and we will work to understand and address them respectfully and with an appropriate level of privacy in the given situation.
 
-### Contributions and Modifications
+## Administrator Information Access
+
+As part of the role, Administrators have information not available to all users. This information includes:
+
+* A member provides email addresses as part of our sign-up process.
+* Information contained within member requests to join the community. This might include email, name, and occupation.
+* Access log information provided by the Slack administrator interface. This includes name, login times, login device, and IP.
+
+Administrators do not have standing access to private channels unless they are members of that channel.
+
+Slack Workplace owners, of which only a limited set of the Admin Team are, have other tools (such as export and migration tools) that may provide access to private channels and DMs. As per the privacy section above, you should not presume anything you say here will remain private, so act accordingly.
+
+As part of Code of Conduct investigations, Administrators may choose to access this information. Administrators may also request information from private channels from current channel members to investigate a Code of Conduct violation.
+
+Administrators may use the above information as part of a Code of Conduct investigation. Usage of this information unrelated to administrator work is forbidden and will be treated as a Code of Conduct violation.
+
+## Administrative Team Guidelines
+
+The Mac Admins Slack Administrative Team are here to ensure that the community runs within the spirit and guidelines of the [Code Of Conduct (CoC)](https://github.com/macadminsdotorg/codeofconduct), and to manage the technical aspects of keeping the Mac Admins Slack instance running. We are also fellow Mac Admins, so when it comes to products, how to do things, why to do things etc - please take our input only as fellow Mac Admins and not as statements or endorsements from the Administrative Team.
+
+On all subjects, other than running of the Mac Admins Slack and the [CoC](https://github.com/macadminsdotorg/codeofconduct), the Administrative Team’s opinions are their own and do not necessarily reflect those of the rest of Mac Admins Slack Administrative Team or the Mac Admins community.
+
+## Contributions and Modifications
 
 Anyone may recommend modifications to this Code of Conduct by opening a pull request [here](https://github.com/macadminsdotorg/codeofconduct). The request will be reviewed by the admin team before being approved and merged.
+
+This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).
+
+VXXX of this Code of Conduct was published on XXXXX, 2022. You can see all prior versions of this artifact [here](https://github.com/macadminsdotorg/codeofconduct/commits/master/README.md).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We hope that you find the community to be enriching to your personal and profess
 
 Thank you for following this code of conduct. We reserve the right to amend or change the code of conduct at any time and encourage you to periodically review these guidelines to ensure a safe environment for all.
 
--The Mac Admins Slack Administrative Team
+- The Mac Admins Slack Administrative Team
 
 
 
@@ -47,7 +47,7 @@ All are welcome to participate in the Slack Workspace as long as the tenets of t
 
 Be a valuable postive contributor to this community. 
 
-Be respectful of others, ask people to stop if you are bothered; respect privacy; understand this community is primarily not-for-profit, and attempt to resolve issues without Administrators, but if you can't resolve an issue, you can contact the Administrators. If you violate this Code of Conduct, it will be made clear to you, and you may be asked to leave the Rands Leadership Slack.
+Be respectful of others, ask people to stop if you are bothered; respect privacy; understand this community is primarily not-for-profit, and attempt to resolve issues without Administrators, but if you can't resolve an issue, you can contact the Administrators. If you violate this Code of Conduct, it will be made clear to you, and you may be asked to leave the Mac Admins Slack.
 
 All community members are expected to:
 
@@ -78,7 +78,7 @@ Respectful behavior includes but is not limited to:
 * Avoid demeaning, discriminatory, harassing, hateful, or physically threatening behavior, speech, and imagery.
 * Due regard for the feelings, wishes, rights, and traditions of others.
 
-If you're unclear if a communication, action, or behavior is respectful, ask someone instead of assuming. No, really. Just ask the ([Administrators](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md)) publicly or privately. We'd rather hear from you than hear about something you said or did after the fact, and we are here to help.
+If you're unclear if a communication, action, or behavior is respectful, ask someone instead of assuming. No, really. Just ask the ([Administrators](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md)) publicly via [#ask-about-this-slack channel](https://macadmins.slack.com/archives/C06PS0JKA) or privately via Direct Message. We'd rather hear from you than hear about something you said or did after the fact, and we are here to help.
 
 Don't be a bystander, be a leader. Role model respectful behavior, but also help to address disrespect when you see it within your community. 
 
@@ -111,7 +111,7 @@ Protect IP and legally-protected information. This community is not a public spa
 
 If you want to disclose anything discussed here in a public channel publicly, use the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule) as the guideline ("participants are free to use the information received, but neither the identity nor the affiliation of the speaker(s), nor that of any other participant, may be revealed"). 
 
-For attribution of specific content found on this Slack on public channels, we ask that you ask the originator of the content for permission. If you don't receive consent in a reasonable time, we ask that you credit the "Rands Leadership Slack."
+For attribution of specific content found on this Slack on public channels, we ask that you ask the originator of the content for permission. If you don't receive consent in a reasonable time, we ask that you credit the "Mac Admins Slack."
 
 **Consequence**: Sharing content from private channels is discouraged without permission of the private channel. 
 
@@ -157,9 +157,9 @@ Should you catch yourself behaving disrespectfully, or be confronted as such, li
 
 If you cannot resolve a situation peacefully, please refer to our [Incident Process](https://github.com/macadminsdotorg/codeofconduct/blob/master/Incident_Process.md) and choose a course of action that suits the situation.
 
-Suppose the Administrators determine that a member is violating any part of this Code of Conduct. In that case, they may take any action they deem appropriate, up to and including expulsion and exclusion from the Rands Leadership Slack. 
+Suppose the Administrators determine that a member is violating any part of this Code of Conduct. In that case, they may take any action they deem appropriate, up to and including expulsion and exclusion from the Mac Admins Slack. 
 
-As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. This Code of Conduct documents everyday situations we've seen, but we can't foresee every situation. If in the Administrator's judgment, the best thing to do is to ask a disrespectful individual to leave, we will do so..
+As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. This Code of Conduct documents everyday situations we've seen, but we can't foresee every situation. If in the Administrator's judgment, the best thing to do is to ask a disrespectful individual to leave, we will do so.
 
 We expect participants to follow these rules in all public and private channels (including direct messages).
 
@@ -167,9 +167,9 @@ We expect participants to follow these rules in all public and private channels 
 
 See [Vendor Guidelines](https://github.com/macadminsdotorg/codeofconduct/blob/master/Vendor_Guidelines.md)
 
-## Press Guidelines
+## Press & Media Guidelines
 
-Additionally, if you are a reporter or a member of the press:
+Additionally, if you are a reporter or a member of the press or media:
 
 * you must have that information listed in your profile - documentation on how to do that is [available here](https://get.slack.help/hc/en-us/articles/204092246-Edit-your-profile)
 * if you want to interview someone about something, you need to ask permission to interview them and inform them about where their comments may end up being published prior to the start of the interview. 

--- a/Vendor_Guidelines.md
+++ b/Vendor_Guidelines.md
@@ -1,10 +1,10 @@
 # Vendor Guidelines
 
-Vendors can make up an important part of our community, and our Slack team provides a unique method to engage with a user base directly, but vendors should adhere to the following guidelines to help ensure they do not engage in behaviour that violates our Code of Conduct.
+Vendors can make up an important part of our community, and our Slack Workspace provides a unique method to engage with a user base directly, but vendors should adhere to the following guidelines to help ensure they do not engage in behaviour that violates our Code of Conduct.
 
 ## Direct messages
 
-It is not permitted to direct message a member of our community for the purposes of promoting your product without their clear permission beforehand.
+It is not permitted to direct message or use other communications tools to contact a member of our community for the purposes of promoting your product without their clear permission beforehand.
 
 ### What is okay
 
@@ -14,8 +14,8 @@ It is not permitted to direct message a member of our community for the purposes
 
 ### What is not okay
 
-* Direct messaging the user before they have responded to a posting in a public channel like the above.
-* Direct messaging the user when they have responded in any manner that could be taken as a negative response to a posting in a public channel like the above.
+* Sending direct messages or using outside communications tools to contact the user before they have responded to a posting in a public channel like the above.
+ * Sending direct messages or using outside communications tools to contact the user when they have responded in any manner that could be taken as a negative response to a posting in a public channel like the above.
 
 ## Promoting your product in public channels
 


### PR DESCRIPTION
Major rework of CoC building on current practices of the Mac Admins Slack Admin Team and other public Slack Team's Code of Conducts - with a focus on documenting and clarifying current processes and objectives of the Admin Team and the Slack in general.