### PR TITLE
Remove excessive item-level numbering from CoC documents

### DIFF
--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -51,10 +51,10 @@ The scope of this agreement is very broad, because this community is very broad.
 
 This Code of Conduct applies to:
 
-- **2.a** All public channels
-- **2.b** All private channels
-- **2.c** Direct messages between members
-- **2.d** Any workspace communication or interaction
+- All public channels
+- All private channels
+- Direct messages between members
+- Any workspace communication or interaction
 
 ## 3. Our Commitment
 
@@ -62,48 +62,48 @@ The Mac Admins Foundation has a clear obligation to keep the Mac Admins Slack a 
 
 We are committed to providing a harassment-free, professional environment for everyone, regardless of:
 
-- **3.a** Gender identity and expression
-- **3.b** Sexual orientation
-- **3.c** Age
-- **3.d** Disability (visible or invisible)
-- **3.e** Physical appearance
-- **3.f** Race and ethnicity
-- **3.g** Nationality
-- **3.h** Language skills and proficiency
-- **3.i** Religion or lack thereof
-- **3.j** Political affiliation
-- **3.k** Professional experience level
-- **3.l** Educational background
+- Gender identity and expression
+- Sexual orientation
+- Age
+- Disability (visible or invisible)
+- Physical appearance
+- Race and ethnicity
+- Nationality
+- Language skills and proficiency
+- Religion or lack thereof
+- Political affiliation
+- Professional experience level
+- Educational background
 
 ## 4. Expected Behavior
 
 All community members are expected to:
 
-- **4.a** Be respectful and professional in all interactions
-- **4.b** Welcome and support new members
-- **4.c** Be patient with language barriers and varying English proficiency
-- **4.d** Give and receive constructive feedback gracefully
-- **4.e** Focus on what is best for the community
-- **4.f** Show empathy toward other community members
-- **4.g** Credit others' work and ideas appropriately
+- Be respectful and professional in all interactions
+- Welcome and support new members
+- Be patient with language barriers and varying English proficiency
+- Give and receive constructive feedback gracefully
+- Focus on what is best for the community
+- Show empathy toward other community members
+- Credit others' work and ideas appropriately
 
 ## 5. Unacceptable Behavior
 
 The following behaviors are not tolerated:
 
-- **5.a** Harassment, intimidation, or discrimination of any kind
-- **5.b** Offensive comments related to protected characteristics
-- **5.c** Unwelcome sexual attention or advances
-- **5.d** Trolling, insulting/derogatory comments, or personal attacks
-- **5.e** Public or private harassment
-- **5.f** Publishing others' private information (doxxing)
-- **5.g** Threats of violence or violent language
-- **5.h** Deliberate intimidation or stalking
-- **5.i** Sustained disruption of discussions
-- **5.j** Spam or unsolicited commercial messages (see [Vendor Policy](./Vendor_Policy.md))
-- **5.k** Sharing of CSAM (child sexual abuse material) or other illegal content
-- **5.l** Scraping, harvesting, or collecting member data without authorization (including email addresses, usernames, profiles, or workspace metadata)
-- **5.m** Any conduct that creates a hostile, intimidating, or exclusionary environment for community members (including sustained patterns of behavior that may individually seem minor but collectively undermine community safety)
+- Harassment, intimidation, or discrimination of any kind
+- Offensive comments related to protected characteristics
+- Unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, or personal attacks
+- Public or private harassment
+- Publishing others' private information (doxxing)
+- Threats of violence or violent language
+- Deliberate intimidation or stalking
+- Sustained disruption of discussions
+- Spam or unsolicited commercial messages (see [Vendor Policy](./Vendor_Policy.md))
+- Sharing of CSAM (child sexual abuse material) or other illegal content
+- Scraping, harvesting, or collecting member data without authorization (including email addresses, usernames, profiles, or workspace metadata)
+- Any conduct that creates a hostile, intimidating, or exclusionary environment for community members (including sustained patterns of behavior that may individually seem minor but collectively undermine community safety)
 
 ## 6. Reporting
 
@@ -111,35 +111,35 @@ The following behaviors are not tolerated:
 
 If you experience or witness unacceptable behavior:
 
-- **6.1.a** **Contact an Admin directly** via direct message
-  - Current Admins are announced monthly in #announce
-  - Any Admin can help, or will connect you with the right person
+1. **Contact an Admin directly** via direct message
+   - Current Admins are announced monthly in #announce
+   - Any Admin can help, or will connect you with the right person
 
-- **6.1.b** **Use the @admins mention** in public channels (for urgent matters)
-  - This notifies all Admins immediately
-  - Use this for urgent safety concerns or ongoing harassment
-  - Note: If you're in a private channel, please DM an Admin directly instead
+2. **Use the @admins mention** in public channels (for urgent matters)
+   - This notifies all Admins immediately
+   - Use this for urgent safety concerns or ongoing harassment
+   - Note: If you're in a private channel, please DM an Admin directly instead
 
-- **6.1.c** **Email:** admin@macadmins.org (if you prefer not to use Slack)
+3. **Email:** admin@macadmins.org (if you prefer not to use Slack)
 
 ### 6.2 What to Include
 
 When reporting, please provide:
 
-- **6.2.a** Your contact information
-- **6.2.b** Description of the incident
-- **6.2.c** Date, time, and location (channel or DM)
-- **6.2.d** Usernames of those involved
-- **6.2.e** Links to messages (if applicable)
-- **6.2.f** Whether the situation is ongoing
-- **6.2.g** Any other relevant context
+- Your contact information
+- Description of the incident
+- Date, time, and location (channel or DM)
+- Usernames of those involved
+- Links to messages (if applicable)
+- Whether the situation is ongoing
+- Any other relevant context
 
 ### 6.3 What to Expect
 
-- **6.3.a** **Acknowledgment:** Within 24 hours (sooner for urgent matters)
-- **6.3.b** **Confidentiality:** Reports are handled privately by the Admin team
-- **6.3.c** **No retaliation:** Reporting in good faith will not result in negative consequences
-- **6.3.d** **Updates:** You'll be informed of the outcome when appropriate
+- **Acknowledgment:** Within 24 hours (sooner for urgent matters)
+- **Confidentiality:** Reports are handled privately by the Admin team
+- **No retaliation:** Reporting in good faith will not result in negative consequences
+- **Updates:** You'll be informed of the outcome when appropriate
 
 ## 7. Enforcement
 
@@ -152,50 +152,50 @@ Violations are categorized by severity:
 **Examples:** Off-topic discussions, mild unprofessional language, first-time minor spam
 
 **Response:**
-- **7.1.1.a** Private warning from Admin
-- **7.1.1.b** Explanation of the issue
-- **7.1.1.c** Guidance on expected behavior
-- **7.1.1.d** No formal record (unless repeated)
+- Private warning from Admin
+- Explanation of the issue
+- Guidance on expected behavior
+- No formal record (unless repeated)
 
 #### 7.1.2 Level 2: Moderate Violation
 
 **Examples:** Repeated Level 1 violations, disrespectful behavior, promotional content after warning, disruptive behavior
 
 **Response:**
-- **7.1.2.a** Formal written warning
-- **7.1.2.b** Required acknowledgment of violation
-- **7.1.2.c** Temporary content removal
-- **7.1.2.d** Incident documented in admin log
-- **7.1.2.e** Potential temporary channel restrictions
+- Formal written warning
+- Required acknowledgment of violation
+- Temporary content removal
+- Incident documented in admin log
+- Potential temporary channel restrictions
 
 #### 7.1.3 Level 3: Serious Violation
 
 **Examples:** Harassment, discriminatory behavior, repeated moderate violations, doxxing, threats, impersonation (including vendor impersonation or astroturfing)
 
 **Response:**
-- **7.1.3.a** Temporary suspension (1-30 days)
-- **7.1.3.b** Formal documentation
-- **7.1.3.c** All members required to acknowledge and commit to following CoC
-- **7.1.3.d** Demonstration of understanding before reinstatement
-- **7.1.3.e** May include permanent channel restrictions
+- Temporary suspension (1-30 days)
+- Formal documentation
+- All members required to acknowledge and commit to following CoC
+- Demonstration of understanding before reinstatement
+- May include permanent channel restrictions
 
 #### 7.1.4 Level 4: Severe Violation
 
 **Examples:** Threats of violence, CSAM, severe harassment, coordinated attacks, repeated serious violations
 
 **Response:**
-- **7.1.4.a** Immediate permanent ban
-- **7.1.4.b** No appeal possible (or very limited circumstances)
-- **7.1.4.c** Law enforcement contacted if appropriate
-- **7.1.4.d** Other communities notified if relevant
+- Immediate permanent ban
+- No appeal possible (or very limited circumstances)
+- Law enforcement contacted if appropriate
+- Other communities notified if relevant
 
 ### 7.2 Progressive Discipline
 
 For repeated violations:
 
-- **7.2.a** First offense: Level-appropriate response
-- **7.2.b** Second offense: Escalate one level
-- **7.2.c** Third offense: Temporary or permanent ban
+1. First offense: Level-appropriate response
+2. Second offense: Escalate one level
+3. Third offense: Temporary or permanent ban
 
 **Note:** Severe violations skip progressive discipline and result in immediate permanent ban.
 
@@ -205,14 +205,14 @@ For repeated violations:
 
 If you believe an enforcement action was made in error:
 
-- **8.1.a** **Contact:** admin@macadmins.org
-- **8.1.b** **Include:**
-  - Your username
-  - Date of enforcement action
-  - Why you believe it was in error
-  - Any supporting evidence
-- **8.1.c** **Timeline:** Appeals reviewed within 7 days
-- **8.1.d** **Decision:** MAF Board makes final decision on appeals
+1. **Contact:** admin@macadmins.org
+2. **Include:**
+   - Your username
+   - Date of enforcement action
+   - Why you believe it was in error
+   - Any supporting evidence
+3. **Timeline:** Appeals reviewed within 7 days
+4. **Decision:** MAF Board makes final decision on appeals
 
 Appeals are only available for Level 2-3 violations. Level 4 (severe) violations have no appeal except in extraordinary circumstances.
 
@@ -220,19 +220,19 @@ Appeals are only available for Level 2-3 violations. Level 4 (severe) violations
 
 If you believe an Admin has violated this Code of Conduct or abused their position:
 
-- **8.2.a** **Contact:** board@macadmins.org (bypasses the admin team)
-- **8.2.b** **Include:**
-  - Admin username
-  - Description of the misconduct
-  - Date, time, and context
-  - Any supporting evidence
-  - How the admin's actions violated the CoC or accountability standards
-- **8.2.c** **Timeline:** MAF Board reviews within 7 days
-- **8.2.d** **Process:**
-  - The admin in question will not participate in the review
-  - Board may consult other admins or community members
-  - Board has authority to remove admins or implement corrective action
-  - You will be notified of the outcome when appropriate
+1. **Contact:** board@macadmins.org (bypasses the admin team)
+2. **Include:**
+   - Admin username
+   - Description of the misconduct
+   - Date, time, and context
+   - Any supporting evidence
+   - How the admin's actions violated the CoC or accountability standards
+3. **Timeline:** MAF Board reviews within 7 days
+4. **Process:**
+   - The admin in question will not participate in the review
+   - Board may consult other admins or community members
+   - Board has authority to remove admins or implement corrective action
+   - You will be notified of the outcome when appropriate
 
 Community members may also petition the MAF Board for admin removal by emailing board@macadmins.org with supporting evidence and community feedback.
 
@@ -240,29 +240,29 @@ Community members may also petition the MAF Board for admin removal by emailing 
 
 Admins are responsible for:
 
-- **9.a** Clarifying standards of acceptable behavior
-- **9.b** Taking appropriate and fair corrective action
-- **9.c** Removing, editing, or rejecting content that violates this CoC
-- **9.d** Temporarily or permanently banning any member for behaviors they deem inappropriate, threatening, offensive, or harmful
-- **9.e** Handling all reports with confidentiality and respect
-- **9.f** Following Admin Runbooks for consistent enforcement
+- Clarifying standards of acceptable behavior
+- Taking appropriate and fair corrective action
+- Removing, editing, or rejecting content that violates this CoC
+- Temporarily or permanently banning any member for behaviors they deem inappropriate, threatening, offensive, or harmful
+- Handling all reports with confidentiality and respect
+- Following Admin Runbooks for consistent enforcement
 
 ### 9.1 Admin Accountability
 
 Admins must maintain the trust of the community and are expected to:
 
-- **9.1.a** **Avoid conflicts of interest:** Admins must not use their position for commercial advantage, to silence criticism of their products/services, to provide preferential treatment for their company, or to advance personal interests
-- **9.1.b** **Recuse when appropriate:** Admins should recuse themselves from enforcement decisions involving their employer, competitors, or situations where they have a personal conflict of interest
-- **9.1.c** **Act impartially:** All enforcement decisions must be made objectively and consistently, regardless of the admin's personal or commercial relationships
-- **9.1.d** **Be transparent:** Admins should disclose relevant affiliations when participating in discussions related to their employer or products
+- **Avoid conflicts of interest:** Admins must not use their position for commercial advantage, to silence criticism of their products/services, to provide preferential treatment for their company, or to advance personal interests
+- **Recuse when appropriate:** Admins should recuse themselves from enforcement decisions involving their employer, competitors, or situations where they have a personal conflict of interest
+- **Act impartially:** All enforcement decisions must be made objectively and consistently, regardless of the admin's personal or commercial relationships
+- **Be transparent:** Admins should disclose relevant affiliations when participating in discussions related to their employer or products
 
 ### 9.2 Consequences of Admin Misconduct
 
 Admins who do not follow or enforce this Code of Conduct, or who abuse their position, may face:
 
-- **9.2.a** Temporary or permanent removal from the Admin team
-- **9.2.b** Temporary or permanent suspension from the Slack workspace
-- **9.2.c** Other corrective action determined by the MAF Board
+- Temporary or permanent removal from the Admin team
+- Temporary or permanent suspension from the Slack workspace
+- Other corrective action determined by the MAF Board
 
 The MAF Board has authority to determine appropriate consequences based on the severity and nature of the misconduct.
 
@@ -270,10 +270,10 @@ The MAF Board has authority to determine appropriate consequences based on the s
 
 Admins have the authority to:
 
-- **10.a** Remove messages or content
-- **10.b** Temporarily or permanently restrict channel access
-- **10.c** Temporarily or permanently suspend or ban members
-- **10.d** Make decisions about workspace settings and policies
+- Remove messages or content
+- Temporarily or permanently restrict channel access
+- Temporarily or permanently suspend or ban members
+- Make decisions about workspace settings and policies
 
 Admin decisions can be appealed to MAF leadership through the process above.
 
@@ -281,13 +281,13 @@ Admin decisions can be appealed to MAF leadership through the process above.
 
 **Important:** Members should be aware of the following data practices:
 
-- **11.a** The Mac Admins Slack operates on a Business+ plan with full message and file retention
-- **11.b** All messages, files, and content are retained permanently in Slack's systems
-- **11.c** Users may request deletion of individual messages, but bulk data deletion or "right to be forgotten" is not available
-- **11.d** Admins can access all channels and DMs if needed for Code of Conduct investigations
-- **11.e** Admin access is logged, auditable, and subject to strict confidentiality policies
-- **11.f** Do not post sensitive information (passwords, credentials, personal data, etc.)
-- **11.g** Assume any content posted may become public
+- The Mac Admins Slack operates on a Business+ plan with full message and file retention
+- All messages, files, and content are retained permanently in Slack's systems
+- Users may request deletion of individual messages, but bulk data deletion or "right to be forgotten" is not available
+- Admins can access all channels and DMs if needed for Code of Conduct investigations
+- Admin access is logged, auditable, and subject to strict confidentiality policies
+- Do not post sensitive information (passwords, credentials, personal data, etc.)
+- Assume any content posted may become public
 
 For more details, see the Data and Privacy section in [Community Guidelines](./Community_Guidelines.md).
 
@@ -295,25 +295,25 @@ For more details, see the Data and Privacy section in [Community Guidelines](./C
 
 This Code of Conduct is supplemented by:
 
-- **12.a** [Community Guidelines](./Community_Guidelines.md) - Detailed expectations and best practices
-- **12.b** [Vendor Policy](./Vendor_Policy.md) - Rules for vendor participation and promotional content
+- [Community Guidelines](./Community_Guidelines.md) - Detailed expectations and best practices
+- [Vendor Policy](./Vendor_Policy.md) - Rules for vendor participation and promotional content
 
 ## 13. Modifications
 
 This Code of Conduct may be updated at any time. Changes will be:
 
-- **13.a** Announced in #announce channel
-- **13.b** Effective 7 days after announcement (for minor changes)
-- **13.c** Effective 30 days after announcement (for major changes)
-- **13.d** Archived versions available for reference
+- Announced in #announce channel
+- Effective 7 days after announcement (for minor changes)
+- Effective 30 days after announcement (for major changes)
+- Archived versions available for reference
 
 ## 14. Attribution
 
 This Code of Conduct is adapted from:
 
-- **14.a** The Contributor Covenant, version 2.1
-- **14.b** The Django Code of Conduct
-- **14.c** Previous Mac Admins Slack Code of Conduct (v1.0)
+- The Contributor Covenant, version 2.1
+- The Django Code of Conduct
+- Previous Mac Admins Slack Code of Conduct (v1.0)
 
 ## 15. License
 
@@ -321,9 +321,9 @@ This Code of Conduct is released under Creative Commons CC BY 4.0.
 
 ## 16. Contact
 
-- **16.a** **Admin Team:** admin@macadmins.org or @admins in Slack
-- **16.b** **MAF Board:** board@macadmins.org
-- **16.c** **Website:** https://www.macadmins.org
+- **Admin Team:** admin@macadmins.org or @admins in Slack
+- **MAF Board:** board@macadmins.org
+- **Website:** https://www.macadmins.org
 
 ## 17. Acknowledgment
 
@@ -340,4 +340,4 @@ By participating in The Mac Admins Slack, you agree to abide by this Code of Con
 | 1.0 | [Previous] | Original Code of Conduct |
 | 2.0 | 2025-10-03 | Major revision: Added enforcement levels, reporting procedures, appeals process, admin responsibilities, and supplementary policy links |
 | 2.1 | 2025-10-10 | Minor revision: Included more narrative language |
-| 3.0 | 2025-11-26 | Added comprehensive section and item numbering for easy reference |
+| 3.0 | 2025-11-26 | Added section numbering for easy reference |

--- a/Community_Guidelines.md
+++ b/Community_Guidelines.md
@@ -32,23 +32,17 @@
   - [8.2 Requires Caution](#82-requires-caution)
   - [8.3 Not Appropriate for This Workspace](#83-not-appropriate-for-this-workspace)
 - [9. Bots and Automation](#9-bots-and-automation)
-  - [9.1 Slash Commands and Integrations](#91-slash-commands-and-integrations)
 - [10. Data and Privacy](#10-data-and-privacy)
   - [10.1 Your Data](#101-your-data)
   - [10.2 Others' Data](#102-others-data)
   - [10.3 Admin Access](#103-admin-access)
 - [11. Recognition and Credit](#11-recognition-and-credit)
-  - [11.1 Giving Credit](#111-giving-credit)
-  - [11.2 Receiving Credit](#112-receiving-credit)
 - [12. When Things Go Wrong](#12-when-things-go-wrong)
   - [12.1 If You Made a Mistake](#121-if-you-made-a-mistake)
   - [12.2 If You're Affected by Someone Else's Behavior](#122-if-youre-affected-by-someone-elses-behavior)
   - [12.3 If You're Contacted by an Admin](#123-if-youre-contacted-by-an-admin)
 - [13. Resources](#13-resources)
 - [14. Getting Help](#14-getting-help)
-  - [14.1 Technical Help](#141-technical-help)
-  - [14.2 Admin Help](#142-admin-help)
-  - [14.3 MAF Questions](#143-maf-questions)
 - [15. Contributing to These Guidelines](#15-contributing-to-these-guidelines)
 - [16. Final Thoughts](#16-final-thoughts)
 - [17. Revision History](#17-revision-history)
@@ -63,20 +57,20 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
 
 ### 2.1 Joining the Workspace
 
-- **2.1.a** Read and understand the [Code of Conduct](./Code_of_Conduct.md)
-- **2.1.b** Complete your profile with your name and role (optional but encouraged)
-- **2.1.c** Introduce yourself in #introductions
-- **2.1.d** Browse channel descriptions to find relevant discussions
+- Read and understand the [Code of Conduct](./Code_of_Conduct.md)
+- Complete your profile with your name and role (optional but encouraged)
+- Introduce yourself in #introductions
+- Browse channel descriptions to find relevant discussions
 
 ### 2.2 Setting Up Your Profile
 
 **Recommended profile information:**
 
-- **2.2.a** Full name (or preferred name)
-- **2.2.b** Current role and organization (optional)
-- **2.2.c** Pronouns (optional)
-- **2.2.d** Time zone (helpful for async communication)
-- **2.2.e** Profile photo (optional)
+- Full name (or preferred name)
+- Current role and organization (optional)
+- Pronouns (optional)
+- Time zone (helpful for async communication)
+- Profile photo (optional)
 
 **Privacy note:** Only share what you're comfortable making public.
 
@@ -84,368 +78,338 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
 
 ### 3.1 General Guidelines
 
-#### 3.1.1 Be Clear and Concise
+**Be Clear and Concise**
+- Threading varies by channel - most channels don't thread as we predate that feature
+- Observe channel norms before posting
+- Break long messages into paragraphs
+- Use formatting (bold, code blocks) appropriately
+- Search before asking - your question may be answered already
 
-- **3.1.1.a** Threading varies by channel - most channels don't thread as we predate that feature
-- **3.1.1.b** Observe channel norms before posting
-- **3.1.1.c** Break long messages into paragraphs
-- **3.1.1.d** Use formatting (bold, code blocks) appropriately
-- **3.1.1.e** Search before asking - your question may be answered already
+**Be Respectful of Time**
+- Use @admins only for urgent admin matters
+- Respect "do not disturb" and timezone differences
+- Be patient waiting for responses - this is an async community
 
-#### 3.1.2 Be Respectful of Time
-
-- **3.1.2.a** Use @admins only for urgent admin matters
-- **3.1.2.b** Respect "do not disturb" and timezone differences
-- **3.1.2.c** Be patient waiting for responses - this is an async community
-
-#### 3.1.3 Be Inclusive
-
-- **3.1.3.a** Remember this is a global community with varying English proficiency
-- **3.1.3.b** Avoid idioms and cultural references that may not translate
-- **3.1.3.c** Be patient with misunderstandings
-- **3.1.3.d** Offer clarification when asked
+**Be Inclusive**
+- Remember this is a global community with varying English proficiency
+- Avoid idioms and cultural references that may not translate
+- Be patient with misunderstandings
+- Offer clarification when asked
 
 ### 3.2 Technical Discussions
 
-#### 3.2.1 Asking Questions
+**Asking Questions**
+- Search Slack history first
+- Provide context (OS version, device model, MDM, etc.)
+- Include error messages or logs (use snippets for long text)
+- Post in the most relevant channel
+- Share what you've already tried so we can help more effectively
+- Update the thread if you solve your own problem
 
-- **3.2.1.a** Search Slack history first
-- **3.2.1.b** Provide context (OS version, device model, MDM, etc.)
-- **3.2.1.c** Include error messages or logs (use snippets for long text)
-- **3.2.1.d** Post in the most relevant channel
-- **3.2.1.e** We're happy to guide you through solving problems—please share what you've already tried so we can help more effectively
-- **3.2.1.f** Update the thread if you solve your own problem
+**Answering Questions**
+- Be kind - everyone was new once
+- Explain your reasoning, don't just post commands
+- Link to documentation when relevant
+- If you're unsure, say so
+- Follow the channel's threading conventions
 
-#### 3.2.2 Answering Questions
-
-- **3.2.2.a** Be kind - everyone was new once
-- **3.2.2.b** Explain your reasoning, don't just post commands
-- **3.2.2.c** Link to documentation when relevant
-- **3.2.2.d** If you're unsure, say so
-- **3.2.2.e** Follow the channel's threading conventions
-
-#### 3.2.3 Sharing Solutions
-
-- **3.2.3.a** Share code snippets as files or formatted code blocks
-- **3.2.3.b** Include comments in scripts
-- **3.2.3.c** Explain any prerequisites or caveats
-- **3.2.3.d** Link to GitHub repos for longer code
-- **3.2.3.e** Credit original authors if adapting their work
+**Sharing Solutions**
+- Share code snippets as files or formatted code blocks
+- Include comments in scripts
+- Explain any prerequisites or caveats
+- Link to GitHub repos for longer code
+- Credit original authors if adapting their work
 
 ### 3.3 Debates and Disagreements
 
-#### 3.3.1 Healthy Debate
+**Healthy Debate**
+- Focus on ideas, not people
+- Use "I" statements: "I've found..." not "You're wrong..."
+- Acknowledge valid points
+- Know when to agree to disagree
+- Consider moving heated discussions to DM
 
-- **3.3.1.a** Focus on ideas, not people
-- **3.3.1.b** Use "I" statements: "I've found..." not "You're wrong..."
-- **3.3.1.c** Acknowledge valid points
-- **3.3.1.d** Know when to agree to disagree
-- **3.3.1.e** Consider moving heated discussions to DM
-
-#### 3.3.2 When Tensions Rise
-
-- **3.3.2.a** Take a break before responding
-- **3.3.2.b** Assume good intent, but remember that impact matters regardless of intent—take responsibility if your words cause harm
-- **3.3.2.c** Ask clarifying questions
-- **3.3.2.d** Invite Admin mediation if needed
-- **3.3.2.e** Remember: being right isn't worth being rude
+**When Tensions Rise**
+- Take a break before responding
+- Assume good intent, but remember that impact matters regardless of intent—take responsibility if your words cause harm
+- Ask clarifying questions
+- Invite Admin mediation if needed
+- Remember: being right isn't worth being rude
 
 ## 4. Channel Etiquette
 
 ### 4.1 Public Channels
 
-#### 4.1.1 On-Topic Conversations
+**On-Topic Conversations**
+- Read channel descriptions and topics
+- Stay generally on-topic
+- Ask Admins if you're unsure where to post
+- Use #random for off-topic chat
 
-- **4.1.1.a** Read channel descriptions and topics
-- **4.1.1.b** Stay generally on-topic
-- **4.1.1.c** Ask Admins if you're unsure where to post
-- **4.1.1.d** Use #random for off-topic chat
+**Cross-Posting**
+- Avoid posting the same question in multiple channels
+- If you must cross-post, mention where else you've posted
+- Don't tag multiple people with the same question
 
-#### 4.1.2 Cross-Posting
-
-- **4.1.2.a** Avoid posting the same question in multiple channels
-- **4.1.2.b** If you must cross-post, mention where else you've posted
-- **4.1.2.c** Don't tag multiple people with the same question
-
-#### 4.1.3 Reactions and Emoji
-
-- **4.1.3.a** Use reactions instead of "+1" messages
-- **4.1.3.b** Common reactions:
+**Reactions and Emoji**
+- Use reactions instead of "+1" messages
+- Common reactions:
   - ✅ = solved/resolved
   - 👀 = I'm looking into this
   - 🙏 = thank you
   - 📝 = documented/noted
 
-#### 4.1.4 Special Channel Structures
+**Special Channel Structures**
 
 Some channels have specific posting and discussion patterns:
 
-- **4.1.4.a** **#appleseed** - Discussion of Apple Seed programs and beta testing
-- **4.1.4.b** **#apple-feedback** - Coordinating Apple feedback submissions
-- **4.1.4.c** **#jamf-product-issues** - Jamf-specific product issues and troubleshooting
-- **4.1.4.d** **#blog-feed / #blog-chat** - Blog posts appear in #blog-feed, discussion happens in #blog-chat
-- **4.1.4.e** **#jobs-board / #jobs-chat** - Job postings go in #jobs-board, discussion happens in #jobs-chat. Threaded replies on specific job postings are fine, but general chatter moves to #jobs-chat.
-- **4.1.4.f** **#politics** - There is a private politics channel. To request access, see the placeholder #politics channel and DM an Admin.
+- **#appleseed** - Discussion of Apple Seed programs and beta testing
+- **#apple-feedback** - Coordinating Apple feedback submissions
+- **#jamf-product-issues** - Jamf-specific product issues and troubleshooting
+- **#blog-feed / #blog-chat** - Blog posts appear in #blog-feed, discussion happens in #blog-chat
+- **#jobs-board / #jobs-chat** - Job postings go in #jobs-board, discussion happens in #jobs-chat. Threaded replies on specific job postings are fine, but general chatter moves to #jobs-chat.
+- **#politics** - There is a private politics channel. To request access, see the placeholder #politics channel and DM an Admin.
 
 ### 4.2 Direct Messages
 
-#### 4.2.1 When to DM
+**When to DM**
+- Sensitive topics not appropriate for public channels
+- Continuing a conversation that's gone off-topic
+- Contacting Admins about CoC violations
+- Networking or mentorship requests (when you have an existing relationship or context from public channels)
 
-- **4.2.1.a** Sensitive topics not appropriate for public channels
-- **4.2.1.b** Continuing a conversation that's gone off-topic
-- **4.2.1.c** Contacting Admins about CoC violations
-- **4.2.1.d** Networking or mentorship requests (when you have an existing relationship or context from public channels)
-
-#### 4.2.2 DM Etiquette
-
-- **4.2.2.a** Ask if someone is open to DMs before sending lengthy messages
-- **4.2.2.b** Respect "no" - not everyone wants to chat privately
-- **4.2.2.c** Don't use DMs to bypass channel guidelines (e.g., unsolicited sales)
-- **4.2.2.d** Report inappropriate DMs to Admins
+**DM Etiquette**
+- Ask if someone is open to DMs before sending lengthy messages
+- Respect "no" - not everyone wants to chat privately
+- Don't use DMs to bypass channel guidelines (e.g., unsolicited sales)
+- Report inappropriate DMs to Admins
 
 ## 5. Vendor and Commercial Participation
 
 See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Summary:
 
 **✅ Acceptable:**
-
-- **5.a** Participating authentically as a community member
-- **5.b** Answering technical questions about your products
-- **5.c** Sharing relevant announcements in appropriate channels
-- **5.d** Transparent disclosure of affiliation
+- Participating authentically as a community member
+- Answering technical questions about your products
+- Sharing relevant announcements in appropriate channels
+- Transparent disclosure of affiliation
 
 **❌ Not Acceptable:**
-
-- **5.e** Cold-calling members via DM
-- **5.f** Posting promotional content without context
-- **5.g** Astroturfing (fake grassroots support) or sockpuppeting (using fake accounts to post testimonials or promote products)
-- **5.h** Impersonation (including vendors/competitors posing as customers)
-- **5.i** Disparaging competitors
-- **5.j** Recruiting without Admin approval
+- Cold-calling members via DM
+- Posting promotional content without context
+- Astroturfing (fake grassroots support) or sockpuppeting (using fake accounts to post testimonials or promote products)
+- Impersonation (including vendors/competitors posing as customers)
+- Disparaging competitors
+- Recruiting without Admin approval
 
 ## 6. Content Sharing
 
 ### 6.1 Links and Resources
 
 **Acceptable:**
-
-- **6.1.a** Blog posts (your own or others')
-- **6.1.b** Documentation and how-to guides
-- **6.1.c** Open source projects
-- **6.1.d** Conference talks and recordings
-- **6.1.e** Relevant news articles
+- Blog posts (your own or others')
+- Documentation and how-to guides
+- Open source projects
+- Conference talks and recordings
+- Relevant news articles
 
 **Guidelines:**
-
-- **6.1.f** Provide context - don't just drop links
-- **6.1.g** Disclose if it's your own content
-- **6.1.h** Use appropriate channels (#blog-posts, #conferences, etc.)
-- **6.1.i** Don't link to paywalled content without mentioning it
+- Provide context - don't just drop links
+- Disclose if it's your own content
+- Use appropriate channels (#blog-posts, #conferences, etc.)
+- Don't link to paywalled content without mentioning it
 
 ### 6.2 Self-Promotion
 
 **Allowed (in moderation):**
-
-- **6.2.a** Sharing your blog posts in #blog-posts
-- **6.2.b** Conference talk announcements in #conferences
-- **6.2.c** Open source project launches in #github
-- **6.2.d** Job postings in #jobs-board (discussion in #jobs-chat)
+- Sharing your blog posts in #blog-posts
+- Conference talk announcements in #conferences
+- Open source project launches in #github
+- Job postings in #jobs-board (discussion in #jobs-chat)
 
 **Not Allowed:**
-
-- **6.2.e** Repeated self-promotion
-- **6.2.f** Off-topic promotion
-- **6.2.g** Promotional content disguised as help
+- Repeated self-promotion
+- Off-topic promotion
+- Promotional content disguised as help
 
 ### 6.3 Screenshots and Recordings
 
-#### 6.3.1 Privacy Considerations
+**Privacy Considerations**
+- Blur or redact sensitive information (names, emails, IPs, etc.)
+- Don't share screenshots of DMs without permission
+- Don't share internal company information
+- Assume workspace conversations are public
 
-- **6.3.1.a** Blur or redact sensitive information (names, emails, IPs, etc.)
-- **6.3.1.b** Don't share screenshots of DMs without permission
-- **6.3.1.c** Don't share internal company information
-- **6.3.1.d** Assume workspace conversations are public
-
-#### 6.3.2 Recording Policy
-
-- **6.3.2.a** Don't record calls without consent
-- **6.3.2.b** Don't share recordings of Slack calls externally
-- **6.3.2.c** Admin team may record calls for training purposes (with notice)
+**Recording Policy**
+- Don't record calls without consent
+- Don't share recordings of Slack calls externally
+- Admin team may record calls for training purposes (with notice)
 
 ## 7. Accessibility and Inclusion
 
 ### 7.1 Making Content Accessible
 
-- **7.1.a** Add alt text to images when possible
-- **7.1.b** Use descriptive link text, not "click here"
-- **7.1.c** Follow channel threading norms
-- **7.1.d** Avoid wall-of-text messages
-- **7.1.e** Use headings in longer posts
+- Add alt text to images when possible
+- Use descriptive link text, not "click here"
+- Follow channel threading norms
+- Avoid wall-of-text messages
+- Use headings in longer posts
 
 ### 7.2 Language and Communication
 
-- **7.2.a** Use clear, simple language
-- **7.2.b** Define acronyms on first use
-- **7.2.c** Be patient with non-native English speakers
-- **7.2.d** Avoid sarcasm - it doesn't translate well
-- **7.2.e** Use emoji thoughtfully (some are culturally specific)
+- Use clear, simple language
+- Define acronyms on first use
+- Be patient with non-native English speakers
+- Avoid sarcasm - it doesn't translate well
+- Use emoji thoughtfully (some are culturally specific)
 
 ### 7.3 Neurodiversity
 
-- **7.3.a** Some members may communicate differently
-- **7.3.b** Be patient with communication styles
-- **7.3.c** Assume good intent
-- **7.3.d** Offer clarification without judgment
+- Some members may communicate differently
+- Be patient with communication styles
+- Assume good intent
+- Offer clarification without judgment
 
 ## 8. Topics to Approach Carefully
 
 ### 8.1 Generally Acceptable (But Be Respectful)
 
-- **8.1.a** Apple platform technical discussions (primary purpose)
-- **8.1.b** IT and systems administration
-- **8.1.c** Career advice and development
-- **8.1.d** Conference and meetup announcements
-- **8.1.e** Industry news relevant to Mac admins
+- Apple platform technical discussions (primary purpose)
+- IT and systems administration
+- Career advice and development
+- Conference and meetup announcements
+- Industry news relevant to Mac admins
 
 ### 8.2 Requires Caution
 
-#### 8.2.1 Politics
+**Politics**
+- There is a private #politics channel available
+- Request access by DMing an Admin (see placeholder channel #politics)
+- General channels: keep politics relevant to our work (tech policy, privacy laws)
+- Admins may intervene if discussions become disruptive
 
-- **8.2.1.a** There is a private #politics channel available
-- **8.2.1.b** Request access by DMing an Admin (see placeholder channel #politics)
-- **8.2.1.c** General channels: keep politics relevant to our work (tech policy, privacy laws)
-- **8.2.1.d** Admins may intervene if discussions become disruptive
+**Religion**
+- Respect all beliefs and non-beliefs
+- Keep discussions civil
+- Don't proselytize
+- Admins may intervene if discussions become contentious
 
-#### 8.2.2 Religion
-
-- **8.2.2.a** Respect all beliefs and non-beliefs
-- **8.2.2.b** Keep discussions civil
-- **8.2.2.c** Don't proselytize
-- **8.2.2.d** Admins may intervene if discussions become contentious
-
-#### 8.2.3 Controversial Topics
-
-- **8.2.3.a** Admins determine what constitutes a controversial topic based on community impact and whether discussions become disruptive
-- **8.2.3.b** Examples include: contentious social issues, divisive current events, sensitive workplace situations
-- **8.2.3.c** Use content warnings for potentially triggering topics (format: "[CW: topic]" at the start of your message)
-- **8.2.3.d** Consider whether Slack is the right venue
-- **8.2.3.e** Move to DMs if requested
-- **8.2.3.f** Stop if asked by Admins
+**Controversial Topics**
+- Admins determine what constitutes a controversial topic based on community impact and whether discussions become disruptive
+- Examples include: contentious social issues, divisive current events, sensitive workplace situations
+- Use content warnings for potentially triggering topics (format: "[CW: topic]" at the start of your message)
+- Consider whether Slack is the right venue
+- Move to DMs if requested
+- Stop if asked by Admins
 
 ### 8.3 Not Appropriate for This Workspace
 
-- **8.3.a** Cryptocurrency promotion or investment advice
-- **8.3.b** Multi-level marketing (MLM)
-- **8.3.c** Political activism unrelated to tech
-- **8.3.d** Personal grievances with employers (use discretion)
-- **8.3.e** Legal advice (we're not lawyers)
-- **8.3.f** Medical advice (we're not doctors)
+- Cryptocurrency promotion or investment advice
+- Multi-level marketing (MLM)
+- Political activism unrelated to tech
+- Personal grievances with employers (use discretion)
+- Legal advice (we're not lawyers)
+- Medical advice (we're not doctors)
 
 ## 9. Bots and Automation
 
 Only MAF-approved bots are enabled in the workspace. User bots and custom integrations are not permitted.
 
-### 9.1 Slash Commands and Integrations
-
-- **9.1.a** Use built-in Slack commands appropriately
-- **9.1.b** Report malfunctioning bots to Admins
+**Slash Commands and Integrations**
+- Use built-in Slack commands appropriately
+- Report malfunctioning bots to Admins
 
 ## 10. Data and Privacy
 
 ### 10.1 Your Data
 
-- **10.1.a** The Mac Admins Slack is on a Business+ plan with full message and file retention
-- **10.1.b** Everything you post is retained permanently in Slack's systems
-- **10.1.c** Users can request deletion of individual messages, but there is no bulk data deletion or "right to be forgotten" option
-- **10.1.d** Don't post sensitive information (passwords, keys, etc.)
-- **10.1.e** Assume anything posted may become public
-- **10.1.f** Be thoughtful about what you post - message history is permanent
+- The Mac Admins Slack is on a Business+ plan with full message and file retention
+- Everything you post is retained permanently in Slack's systems
+- Users can request deletion of individual messages, but there is no bulk data deletion or "right to be forgotten" option
+- Don't post sensitive information (passwords, keys, etc.)
+- Assume anything posted may become public
+- Be thoughtful about what you post - message history is permanent
 
 ### 10.2 Others' Data
 
-- **10.2.a** Don't collect member data without permission
-- **10.2.b** Don't scrape the workspace
-- **10.2.c** Don't share member information outside Slack
-- **10.2.d** Report data harvesting to Admins
+- Don't collect member data without permission
+- Don't scrape the workspace
+- Don't share member information outside Slack
+- Report data harvesting to Admins
 
 ### 10.3 Admin Access
 
-- **10.3.a** Admins can access all channels and DMs if needed for investigations
-- **10.3.b** Admins follow strict confidentiality policies
-- **10.3.c** Data access is logged and auditable
-- **10.3.d** Admin Runbooks available for admins
+- Admins can access all channels and DMs if needed for investigations
+- Admins follow strict confidentiality policies
+- Data access is logged and auditable
+- Admin Runbooks available for admins
 
 ## 11. Recognition and Credit
 
-### 11.1 Giving Credit
+**Giving Credit**
+- Credit others' work and ideas
+- Link to original sources
+- Tag people when sharing their content
+- Say thank you
 
-- **11.1.a** Credit others' work and ideas
-- **11.1.b** Link to original sources
-- **11.1.c** Tag people when sharing their content
-- **11.1.d** Say thank you
-
-### 11.2 Receiving Credit
-
-- **11.2.a** Accept credit gracefully
-- **11.2.b** Acknowledge collaborators
-- **11.2.c** Share the spotlight
+**Receiving Credit**
+- Accept credit gracefully
+- Acknowledge collaborators
+- Share the spotlight
 
 ## 12. When Things Go Wrong
 
 ### 12.1 If You Made a Mistake
 
-- **12.1.a** Acknowledge it
-- **12.1.b** Apologize if appropriate
-- **12.1.c** Learn from it
-- **12.1.d** Move forward
+1. Acknowledge it
+2. Apologize if appropriate
+3. Learn from it
+4. Move forward
 
 ### 12.2 If You're Affected by Someone Else's Behavior
 
-- **12.2.a** Consider addressing it directly (if safe and comfortable)
-- **12.2.b** Report to Admins if it violates the CoC
-- **12.2.c** Use the mute or block features if needed
-- **12.2.d** Know that Admins take reports seriously
+1. Consider addressing it directly (if safe and comfortable)
+2. Report to Admins if it violates the CoC
+3. Use the mute or block features if needed
+4. Know that Admins take reports seriously
 
 ### 12.3 If You're Contacted by an Admin
 
-- **12.3.a** Respond promptly and respectfully
-- **12.3.b** Provide your perspective
-- **12.3.c** Ask questions if you don't understand
-- **12.3.d** Accept the outcome gracefully (or use appeals process)
+- Respond promptly and respectfully
+- Provide your perspective
+- Ask questions if you don't understand
+- Accept the outcome gracefully (or use appeals process)
 
 ## 13. Resources
 
-- **13.a** [Code of Conduct](./Code_of_Conduct.md) - What's not acceptable
-- **13.b** [Vendor Policy](./Vendor_Policy.md) - Guidelines for vendors
-- **13.c** [Admin Channels](./admin-channels.md) - How to contact Admins
-- **13.d** [Escalation Matrix](./escalation-matrix.md) - How Admins handle issues
+- [Code of Conduct](./Code_of_Conduct.md) - What's not acceptable
+- [Vendor Policy](./Vendor_Policy.md) - Guidelines for vendors
+- [Admin Channels](./admin-channels.md) - How to contact Admins
+- [Escalation Matrix](./escalation-matrix.md) - How Admins handle issues
 
 ## 14. Getting Help
 
-### 14.1 Technical Help
+**Technical Help**
+- Post in relevant technical channels
+- Search history first
+- Provide context and details
 
-- **14.1.a** Post in relevant technical channels
-- **14.1.b** Search history first
-- **14.1.c** Provide context and details
+**Admin Help**
+- DM any Admin for questions
+- Use @admins for urgent matters
+- Email admin@macadmins.org
 
-### 14.2 Admin Help
-
-- **14.2.a** DM any Admin for questions
-- **14.2.b** Use @admins for urgent matters
-- **14.2.c** Email admin@macadmins.org
-
-### 14.3 MAF Questions
-
-- **14.3.a** #macadminsfoundation channel
-- **14.3.b** board@macadmins.org
+**MAF Questions**
+- #macadminsfoundation channel
+- board@macadmins.org
 
 ## 15. Contributing to These Guidelines
 
 These guidelines evolve based on community needs. To suggest improvements:
 
-- **15.a** Open an issue in the [runbooks repository](https://github.com/macadminsdotorg/runbooks)
-- **15.b** Discuss in #macadminsfoundation
-- **15.c** Contact an Admin or MAF Board member
+1. Open an issue in the [runbooks repository](https://github.com/macadminsdotorg/runbooks)
+2. Discuss in #macadminsfoundation
+3. Contact an Admin or MAF Board member
 
 ## 16. Final Thoughts
 
@@ -462,4 +426,4 @@ Welcome to The Mac Admins Slack!
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | 2025-10-03 | Initial community guidelines |
-| 1.1 | 2025-11-26 | Added comprehensive section and item numbering for easy reference |
+| 1.1 | 2025-11-26 | Added section numbering for easy reference |

--- a/Vendor_Guidelines.md
+++ b/Vendor_Guidelines.md
@@ -12,6 +12,7 @@ Vendors can make up an important part of our community, and our Slack Workspace 
   - [2.2 What is not OK](#22-what-is-not-ok)
 - [3. The `#vendor-announce` Channel](#3-the-vendor-announce-channel)
 - [4. Use of Private Channels](#4-use-of-private-channels)
+- [5. Revision History](#5-revision-history)
 
 ---
 
@@ -37,9 +38,9 @@ Sending direct messages or using outside communications tools to contact the use
 
 If you wish to promote your product in a public channel, it is important that:
 
-- **2.a** Your message is relevant to the current discussion topic. For example, if you make a disk partitioning tool, it may be useful to post a link to your own channel if the current discussion is on that topic.
-- **2.b** Your message cannot be considered 'spam' - in addition to being on topic, it shouldn't be posted repeatedly, either in the same channel or in multiple channels.
-- **2.c** Your participation is timely and current, and not creating or adding to zombie threads that are more than 30 days without activity.
+- Your message is relevant to the current discussion topic. For example, if you make a disk partitioning tool, it may be useful to post a link to your own channel if the current discussion is on that topic.
+- Your message cannot be considered 'spam' - in addition to being on topic, it shouldn't be posted repeatedly, either in the same channel or in multiple channels.
+- Your participation is timely and current, and not creating or adding to zombie threads that are more than 30 days without activity.
 
 ### 2.1 What is OK
 
@@ -61,9 +62,9 @@ We have created the `#vendor-announce` channel so that vendors, startups, and an
 
 You must still adhere to the remaining guidelines:
 
-- **3.a** While this channel is meant for promotions, it can still be considered 'spam' if you post repeatedly or cross-post to other channels.
-- **3.b** It is advised to create a new channel for your product, service, or tool, and invite people to join that channel if they wish to hear anything more about it.
-- **3.c** Do not add direct links in the `#vendor-announce` channel to any competitions, giveaways, surveys, or other means of gathering personal information. Instead, direct people to your own channel or your own website.
+- While this channel is meant for promotions, it can still be considered 'spam' if you post repeatedly or cross-post to other channels.
+- It is advised to create a new channel for your product, service, or tool, and invite people to join that channel if they wish to hear anything more about it.
+- Do not add direct links in the `#vendor-announce` channel to any competitions, giveaways, surveys, or other means of gathering personal information. Instead, direct people to your own channel or your own website.
 
 ## 4. Use of Private Channels
 
@@ -76,6 +77,6 @@ The Mac Admins Slack is not a substitute for a vendor operating their own platfo
 | Version | Date | Changes |
 |---------|------|---------|
 | 3.0 | September 2025 | Previous version |
-| 3.1 | November 2025 | Added comprehensive section and item numbering for easy reference |
+| 3.1 | November 2025 | Added section numbering for easy reference |
 
 You can see all prior versions of this artifact in the [commit history](https://github.com/macadminsdotorg/codeofconduct/commits/master/Vendor_Guidelines.md).

--- a/Vendor_Policy.md
+++ b/Vendor_Policy.md
@@ -31,22 +31,12 @@
   - [7.4 Vendor Conflicts](#74-vendor-conflicts)
 - [8. Identity Verification for Vendors](#8-identity-verification-for-vendors)
 - [9. Enforcement](#9-enforcement)
-  - [9.1 First Violation (Minor)](#91-first-violation-minor)
-  - [9.2 Second Violation or Moderate First Violation](#92-second-violation-or-moderate-first-violation)
-  - [9.3 Serious or Repeated Violations](#93-serious-or-repeated-violations)
-  - [9.4 Severe Violations](#94-severe-violations)
 - [10. Vendor Benefits](#10-vendor-benefits)
 - [11. Best Practices for Vendors](#11-best-practices-for-vendors)
-  - [11.1 Do's](#111-dos)
-  - [11.2 Don'ts](#112-donts)
 - [12. Vendor Resources](#12-vendor-resources)
-  - [12.1 For New Vendors](#121-for-new-vendors)
-  - [12.2 For Questions](#122-for-questions)
 - [13. Reporting Vendor Violations](#13-reporting-vendor-violations)
 - [14. For Admins](#14-for-admins)
 - [15. Examples](#15-examples)
-  - [15.1 Good Vendor Participation](#151-good-vendor-participation)
-  - [15.2 Bad Vendor Participation](#152-bad-vendor-participation)
 - [16. Version History](#16-version-history)
 
 ---
@@ -59,193 +49,170 @@ The Mac Admins Slack welcomes vendors as community members. This policy clarifie
 
 This policy applies to:
 
-- **2.a** Employees of commercial vendors
-- **2.b** Contractors and consultants
-- **2.c** Independent developers selling products
-- **2.d** Service providers
-- **2.e** Anyone with commercial interests in products/services relevant to Mac administration
+- Employees of commercial vendors
+- Contractors and consultants
+- Independent developers selling products
+- Service providers
+- Anyone with commercial interests in products/services relevant to Mac administration
 
 ## 3. Philosophy
 
 **We welcome vendors who:**
-
-- **3.a** Participate authentically as community members
-- **3.b** Share expertise and help solve problems
-- **3.c** Are transparent about their affiliations
-- **3.d** Respect community norms
+- Participate authentically as community members
+- Share expertise and help solve problems
+- Are transparent about their affiliations
+- Respect community norms
 
 **We don't welcome:**
-
-- **3.e** Aggressive sales tactics
-- **3.f** Spam or unsolicited promotions
-- **3.g** Astroturfing or fake testimonials
-- **3.h** Competitor disparagement
+- Aggressive sales tactics
+- Spam or unsolicited promotions
+- Astroturfing or fake testimonials
+- Competitor disparagement
 
 ## 4. Vendor Participation Guidelines
 
 ### 4.1 Acceptable Vendor Behavior
 
-#### 4.1.1 Authentic Participation
+**Authentic Participation**
+- Answer technical questions about your products honestly
+- Share your expertise on relevant topics (even unrelated to your products)
+- Participate in discussions without pushing your products
+- Build genuine relationships with community members
 
-- **4.1.1.a** Answer technical questions about your products honestly
-- **4.1.1.b** Share your expertise on relevant topics (even unrelated to your products)
-- **4.1.1.c** Participate in discussions without pushing your products
-- **4.1.1.d** Build genuine relationships with community members
+**Transparent Disclosure**
+- Include your company affiliation in your Slack profile
+- Disclose your relationship when discussing your products
+- Be upfront about being a vendor
+- Clearly mark announcements as commercial
 
-#### 4.1.2 Transparent Disclosure
+**Helpful Content**
+- Share documentation, guides, and how-tos
+- Provide troubleshooting assistance
+- Answer questions about your products
+- Acknowledge limitations and bugs honestly
 
-- **4.1.2.a** Include your company affiliation in your Slack profile
-- **4.1.2.b** Disclose your relationship when discussing your products
-- **4.1.2.c** Be upfront about being a vendor
-- **4.1.2.d** Clearly mark announcements as commercial
+**Product Announcements**
+- New product launches (with context, not just links)
+- Major feature releases
+- Security updates or critical information
+- Community-relevant news
 
-#### 4.1.3 Helpful Content
-
-- **4.1.3.a** Share documentation, guides, and how-tos
-- **4.1.3.b** Provide troubleshooting assistance
-- **4.1.3.c** Answer questions about your products
-- **4.1.3.d** Acknowledge limitations and bugs honestly
-
-#### 4.1.4 Product Announcements
-
-- **4.1.4.a** New product launches (with context, not just links)
-- **4.1.4.b** Major feature releases
-- **4.1.4.c** Security updates or critical information
-- **4.1.4.d** Community-relevant news
-
-#### 4.1.5 Event Participation
-
-- **4.1.5.a** Announce conference booths/presentations
-- **4.1.5.b** Share conference discount codes (occasionally)
-- **4.1.5.c** Invite community to vendor-hosted events
-- **4.1.5.d** Participate in community events authentically
+**Event Participation**
+- Announce conference booths/presentations
+- Share conference discount codes (occasionally)
+- Invite community to vendor-hosted events
+- Participate in community events authentically
 
 ### 4.2 Unacceptable Vendor Behavior
 
-#### 4.2.1 Spam and Unwanted Promotion
+**Spam and Unwanted Promotion**
+- Cold-calling members via DM with sales pitches
+- Posting promotional content without context or value
+- Repeated mentions of your product in unrelated discussions
+- Link-dropping without contributing to conversation
+- Posting the same promotion in multiple channels
 
-- **4.2.1.a** Cold-calling members via DM with sales pitches
-- **4.2.1.b** Posting promotional content without context or value
-- **4.2.1.c** Repeated mentions of your product in unrelated discussions
-- **4.2.1.d** Link-dropping without contributing to conversation
-- **4.2.1.e** Posting the same promotion in multiple channels
+**Deceptive Practices**
+- Creating fake accounts to post fake testimonials or promote products
+- Paying members to promote your product without disclosure
+- Sock-puppeting (using fake accounts to amplify support for your legitimate account or product)
+- Astroturfing (creating fake grassroots enthusiasm or testimonials)
+- Misrepresenting product capabilities
+- Hiding your vendor affiliation
 
-#### 4.2.2 Deceptive Practices
+**Competitor Disparagement**
+- Bashing competitor products
+- Spreading FUD (Fear, Uncertainty, and Doubt) about competitors
+- Comparing your product to competitors unsolicited
+- Brigading discussions about competitor products
 
-- **4.2.2.a** Creating fake accounts to post fake testimonials or promote products
-- **4.2.2.b** Paying members to promote your product without disclosure
-- **4.2.2.c** Sock-puppeting (using fake accounts to amplify support for your legitimate account or product)
-- **4.2.2.d** Astroturfing (creating fake grassroots enthusiasm or testimonials)
-- **4.2.2.e** Misrepresenting product capabilities
-- **4.2.2.f** Hiding your vendor affiliation
+**Aggressive Sales Tactics**
+- Pressuring members to buy
+- Following up after a "no"
+- Making exaggerated or false claims
+- Creating false urgency ("limited time offer" spam)
 
-#### 4.2.3 Competitor Disparagement
-
-- **4.2.3.a** Bashing competitor products
-- **4.2.3.b** Spreading FUD (Fear, Uncertainty, and Doubt) about competitors
-- **4.2.3.c** Comparing your product to competitors unsolicited
-- **4.2.3.d** Brigading discussions about competitor products
-
-#### 4.2.4 Aggressive Sales Tactics
-
-- **4.2.4.a** Pressuring members to buy
-- **4.2.4.b** Following up after a "no"
-- **4.2.4.c** Making exaggerated or false claims
-- **4.2.4.d** Creating false urgency ("limited time offer" spam)
-
-#### 4.2.5 Recruiting Violations
-
-- **4.2.5.a** Mass-recruiting members via DM
-- **4.2.5.b** Posting job listings outside #jobs-board
-- **4.2.5.c** Headhunting without Admin approval
-- **4.2.5.d** Aggressive talent recruitment
+**Recruiting Violations**
+- Mass-recruiting members via DM
+- Posting job listings outside #jobs-board
+- Headhunting without Admin approval
+- Aggressive talent recruitment
 
 ## 5. Channel-Specific Guidelines
 
 ### 5.1 Technical Channels (#mac, #ios, #jamf, etc.)
 
 **Allowed:**
-
-- **5.1.a** Answering questions about your products
-- **5.1.b** Sharing relevant technical insights
-- **5.1.c** Linking to documentation when helpful
-- **5.1.d** Participating in technical discussions
+- Answering questions about your products
+- Sharing relevant technical insights
+- Linking to documentation when helpful
+- Participating in technical discussions
 
 **Not Allowed:**
-
-- **5.1.e** Pushing your product when others are mentioned
-- **5.1.f** Derailing discussions to promote your solution
-- **5.1.g** Claiming your product is the only solution
+- Pushing your product when others are mentioned
+- Derailing discussions to promote your solution
+- Claiming your product is the only solution
 
 ### 5.2 #blog-posts
 
 **Allowed:**
-
-- **5.2.a** Sharing your own blog posts (vendor or personal)
-- **5.2.b** Provide brief context in your post
-- **5.2.c** Include disclosure if company blog
+- Sharing your own blog posts (vendor or personal)
+- Provide brief context in your post
+- Include disclosure if company blog
 
 **Not Allowed:**
-
-- **5.2.d** Purely promotional posts without technical value
-- **5.2.e** Repeated sharing of old content
-- **5.2.f** Link-only posts with no context
+- Purely promotional posts without technical value
+- Repeated sharing of old content
+- Link-only posts with no context
 
 ### 5.3 #conferences
 
 **Allowed:**
-
-- **5.3.a** Announcing your conference presence
-- **5.3.b** Sharing booth/session information
-- **5.3.c** Offering community discount codes
-- **5.3.d** Conference-related news
+- Announcing your conference presence
+- Sharing booth/session information
+- Offering community discount codes
+- Conference-related news
 
 **Not Allowed:**
-
-- **5.3.e** Pure sales pitches disguised as conference announcements
-- **5.3.f** Repeatedly posting about the same event
-- **5.3.g** Collecting attendee email addresses or member data without explicit consent
-- **5.3.h** Using conference attendance to scrape or harvest member information
+- Pure sales pitches disguised as conference announcements
+- Repeatedly posting about the same event
+- Collecting attendee email addresses or member data without explicit consent
+- Using conference attendance to scrape or harvest member information
 
 ### 5.4 #meetups
 
 **Allowed:**
-
-- **5.4.a** Announcing local or virtual meetups open to the community
-- **5.4.b** Sharing meetup details and registration information
-- **5.4.c** Organizing community-focused events
+- Announcing local or virtual meetups open to the community
+- Sharing meetup details and registration information
+- Organizing community-focused events
 
 **Requirements:**
-
-- **5.4.d** Events must be open to all community members who wish to attend
-- **5.4.e** No vendor-exclusive events or customer-only gatherings
-- **5.4.f** If a meeting is internal or limited to specific groups, do not post in #meetups
-- **5.4.g** Be transparent about any vendor sponsorship or hosting
+- Events must be open to all community members who wish to attend
+- No vendor-exclusive events or customer-only gatherings
+- If a meeting is internal or limited to specific groups, do not post in #meetups
+- Be transparent about any vendor sponsorship or hosting
 
 **Not Allowed:**
-
-- **5.4.h** Posting invite-only events exclusive to your customers
-- **5.4.i** Posting internal company meetings or closed-door events
-- **5.4.j** Using meetups as exclusive lead generation or sales opportunities
+- Posting invite-only events exclusive to your customers
+- Posting internal company meetings or closed-door events
+- Using meetups as exclusive lead generation or sales opportunities
 
 ### 5.5 #vendor-announce
 
 **Purpose:** Did you make something and want the world to know about it? Tell us about it! Commercial activity is permitted in this channel.
 
 **Allowed:**
-
-- **5.5.a** Product announcements and launches
-- **5.5.b** Major updates and new features
-- **5.5.c** Open-source project releases
-- **5.5.d** Commercial products and services
-- **5.5.e** Include context and value proposition
+- Product announcements and launches
+- Major updates and new features
+- Open-source project releases
+- Commercial products and services
+- Include context and value proposition
 
 **Guidelines:**
-
-- **5.5.f** This is the primary channel for vendor announcements
-- **5.5.g** Be clear about what you're announcing
-- **5.5.h** Provide relevant links and details
-- **5.5.i** Commercial promotion is explicitly allowed here
+- This is the primary channel for vendor announcements
+- Be clear about what you're announcing
+- Provide relevant links and details
+- Commercial promotion is explicitly allowed here
 
 ### 5.6 #jobs-board and #jobs-chat
 
@@ -253,58 +220,52 @@ This policy applies to:
 **#jobs-chat** - Discuss jobs, career advice, general job talk
 
 **Requirements:**
-
-- **5.6.a** Post jobs relevant to Mac admins
-- **5.6.b** Include location/remote status
-- **5.6.c** Include salary range if required by local law (CA, CO, NYC, etc.)
-- **5.6.d** Salary disclosure encouraged for all postings but required where legally mandated
-- **5.6.e** Postings without legally required salary info will be removed
-- **5.6.f** Threaded discussion about specific jobs is fine, general chatter goes to #jobs-chat
+- Post jobs relevant to Mac admins
+- Include location/remote status
+- Include salary range if required by local law (CA, CO, NYC, etc.)
+- Salary disclosure encouraged for all postings but required where legally mandated
+- Postings without legally required salary info will be removed
+- Threaded discussion about specific jobs is fine, general chatter goes to #jobs-chat
 
 **Not Allowed:**
-
-- **5.6.g** Mass recruiting via DM
-- **5.6.h** Posting outside #jobs-board
-- **5.6.i** Reposting the same job repeatedly without updates
+- Mass recruiting via DM
+- Posting outside #jobs-board
+- Reposting the same job repeatedly without updates
 
 ### 5.7 Social Channels
 
-- **5.7.a** Participate as a community member, not a vendor
-- **5.7.b** Off-topic chat is welcome
-- **5.7.c** Don't turn social conversations into sales opportunities
+- Participate as a community member, not a vendor
+- Off-topic chat is welcome
+- Don't turn social conversations into sales opportunities
 
 ## 6. Direct Messages (DMs)
 
 ### 6.1 Acceptable DM Use
 
 **With Permission:**
-
-- **6.1.a** Following up on public conversations
-- **6.1.b** Answering specific questions about your product
-- **6.1.c** Scheduling demos when requested
-- **6.1.d** Networking and relationship building
+- Following up on public conversations
+- Answering specific questions about your product
+- Scheduling demos when requested
+- Networking and relationship building
 
 **Generally OK:**
-
-- **6.1.e** Responding to someone who DMed you first
-- **6.1.f** Following up on explicit requests for information
-- **6.1.g** Sharing pricing when asked
+- Responding to someone who DMed you first
+- Following up on explicit requests for information
+- Sharing pricing when asked
 
 ### 6.2 Unacceptable DM Use
 
 **Never OK:**
-
-- **6.2.a** Cold outreach with sales pitches
-- **6.2.b** Bulk messaging members
-- **6.2.c** Continuing after being told no
-- **6.2.d** Pressuring for meetings or demos
+- Cold outreach with sales pitches
+- Bulk messaging members
+- Continuing after being told no
+- Pressuring for meetings or demos
 
 **If someone says "no" in DMs:**
-
-- **6.2.e** Thank them for their time
-- **6.2.f** Stop following up
-- **6.2.g** Don't ask "why not"
-- **6.2.h** Move on gracefully
+- Thank them for their time
+- Stop following up
+- Don't ask "why not"
+- Move on gracefully
 
 ## 7. Special Circumstances
 
@@ -312,10 +273,10 @@ This policy applies to:
 
 Occasionally, MAF may approve sponsored content or partnerships. This requires:
 
-- **7.1.a** Advance approval from MAF Board
-- **7.1.b** Clear disclosure as sponsored content
-- **7.1.c** Value for the community
-- **7.1.d** Alignment with community values
+- Advance approval from MAF Board
+- Clear disclosure as sponsored content
+- Value for the community
+- Alignment with community values
 
 Contact: board@macadmins.org
 
@@ -323,57 +284,52 @@ Contact: board@macadmins.org
 
 Vendors seeking product feedback or conducting research:
 
-- **7.2.a** Request Admin approval first
-- **7.2.b** Post in appropriate channels
-- **7.2.c** Be transparent about your goals
-- **7.2.d** Respect members who decline
-- **7.2.e** Share findings with community when appropriate
+- Request Admin approval first
+- Post in appropriate channels
+- Be transparent about your goals
+- Respect members who decline
+- Share findings with community when appropriate
 
 ### 7.3 Competitive Analysis
 
 **Acceptable:**
-
-- **7.3.a** Honest feature comparisons when asked
-- **7.3.b** Objective discussions of product differences
-- **7.3.c** Acknowledging where competitors excel
+- Honest feature comparisons when asked
+- Objective discussions of product differences
+- Acknowledging where competitors excel
 
 **Not Acceptable:**
-
-- **7.3.d** Proactively disparaging competitors
-- **7.3.e** Spreading rumors or FUD
-- **7.3.f** Using community to attack competitors
+- Proactively disparaging competitors
+- Spreading rumors or FUD
+- Using community to attack competitors
 
 ### 7.4 Vendor Conflicts
 
 If two vendors from competing companies have a disagreement:
 
-- **7.4.a** Keep it professional
-- **7.4.b** Focus on facts, not attacks
-- **7.4.c** Consider taking to DM
-- **7.4.d** Involve Admins if needed
-- **7.4.e** Remember: you're representing your company
+- Keep it professional
+- Focus on facts, not attacks
+- Consider taking to DM
+- Involve Admins if needed
+- Remember: you're representing your company
 
 ## 8. Identity Verification for Vendors
 
 Admins may request verification of vendor identity to ensure authenticity and prevent impersonation.
 
 **When verification is requested:**
-
-- **8.a** Typically after a vendor becomes an active participant in discussions
-- **8.b** May be triggered by community reports or concerns
-- **8.c** Can be proactive for vendors in high-visibility roles
+- Typically after a vendor becomes an active participant in discussions
+- May be triggered by community reports or concerns
+- Can be proactive for vendors in high-visibility roles
 
 **Verification methods may include:**
-
-- **8.d** LinkedIn profile confirmation
-- **8.e** Company email verification
-- **8.f** Video call verification (for active participants)
+- LinkedIn profile confirmation
+- Company email verification
+- Video call verification (for active participants)
 
 **What happens if verification is refused:**
-
-- **8.g** Vendor may be subject to additional scrutiny
-- **8.h** Possible restrictions on promotional activities
-- **8.i** In cases of suspected impersonation, temporary suspension pending verification
+- Vendor may be subject to additional scrutiny
+- Possible restrictions on promotional activities
+- In cases of suspected impersonation, temporary suspension pending verification
 
 Verification is not required for all vendors—only when authenticity concerns arise or for vendors with significant community presence.
 
@@ -381,111 +337,99 @@ Verification is not required for all vendors—only when authenticity concerns a
 
 Vendor policy violations are handled according to the [Code of Conduct](./Code_of_Conduct.md) enforcement procedures:
 
-### 9.1 First Violation (Minor)
+**First Violation (Minor)**
+- Private warning from Admin
+- Guidance on acceptable behavior
+- Removal of offending content
 
-- **9.1.a** Private warning from Admin
-- **9.1.b** Guidance on acceptable behavior
-- **9.1.c** Removal of offending content
+**Second Violation or Moderate First Violation**
+- Formal warning documented
+- Temporary content restrictions
+- May require company leadership notification
 
-### 9.2 Second Violation or Moderate First Violation
+**Serious or Repeated Violations**
+- Temporary suspension (company-wide or individual)
+- Permanent channel restrictions
+- Company-wide ban for egregious violations
 
-- **9.2.a** Formal warning documented
-- **9.2.b** Temporary content restrictions
-- **9.2.c** May require company leadership notification
-
-### 9.3 Serious or Repeated Violations
-
-- **9.3.a** Temporary suspension (company-wide or individual)
-- **9.3.b** Permanent channel restrictions
-- **9.3.c** Company-wide ban for egregious violations
-
-### 9.4 Severe Violations
-
-- **9.4.a** Immediate permanent ban
-- **9.4.b** Possible escalation to legal (for harassment, doxxing, etc.)
-- **9.4.c** Notification to other communities if relevant
+**Severe Violations**
+- Immediate permanent ban
+- Possible escalation to legal (for harassment, doxxing, etc.)
+- Notification to other communities if relevant
 
 ## 10. Vendor Benefits
 
 Vendors who follow these guidelines and participate authentically receive:
 
 **Community Trust**
-
-- **10.a** Established as industry experts
-- **10.b** Trusted sources of information
-- **10.c** Authentic relationships with customers
+- Established as industry experts
+- Trusted sources of information
+- Authentic relationships with customers
 
 **Visibility**
-
-- **10.d** Natural product mentions and discussions
-- **10.e** Positive word-of-mouth
-- **10.f** Community advocacy
+- Natural product mentions and discussions
+- Positive word-of-mouth
+- Community advocacy
 
 **Product Feedback**
-
-- **10.g** Real-world usage insights
-- **10.h** Bug reports and feature requests
-- **10.i** Beta testing opportunities
+- Real-world usage insights
+- Bug reports and feature requests
+- Beta testing opportunities
 
 **Talent Pipeline**
-
-- **10.j** Access to skilled professionals
-- **10.k** Organic recruiting opportunities
-- **10.l** Industry reputation building
+- Access to skilled professionals
+- Organic recruiting opportunities
+- Industry reputation building
 
 ## 11. Best Practices for Vendors
 
-### 11.1 Do's
+**Do's**
+- Complete your profile with company affiliation
+- Participate regularly, not just to promote
+- Be helpful even when it doesn't benefit your product
+- Answer questions honestly, including limitations
+- Give credit to competitors when deserved
+- Thank people for feedback, even critical feedback
+- Admit mistakes quickly and transparently
+- Build relationships before asking for anything
 
-- **11.1.a** Complete your profile with company affiliation
-- **11.1.b** Participate regularly, not just to promote
-- **11.1.c** Be helpful even when it doesn't benefit your product
-- **11.1.d** Answer questions honestly, including limitations
-- **11.1.e** Give credit to competitors when deserved
-- **11.1.f** Thank people for feedback, even critical feedback
-- **11.1.g** Admit mistakes quickly and transparently
-- **11.1.h** Build relationships before asking for anything
-
-### 11.2 Don'ts
-
-- **11.2.a** Join just to promote your product
-- **11.2.b** Use burner accounts or hide affiliation
-- **11.2.c** Get defensive about criticism
-- **11.2.d** Argue with customers publicly
-- **11.2.e** Promise fixes without delivering
-- **11.2.f** Bad-mouth competitors
-- **11.2.g** Track community sentiment for competitive advantage without giving back
+**Don'ts**
+- Join just to promote your product
+- Use burner accounts or hide affiliation
+- Get defensive about criticism
+- Argue with customers publicly
+- Promise fixes without delivering
+- Bad-mouth competitors
+- Track community sentiment for competitive advantage without giving back
 
 ## 12. Vendor Resources
 
-### 12.1 For New Vendors
+**For New Vendors**
+1. Read the [Code of Conduct](./Code_of_Conduct.md)
+2. Read the [Community Guidelines](./Community_Guidelines.md)
+3. Complete your Slack profile with company info
+4. Introduce yourself in #introductions (mention your company)
+5. Observe conversations for a few weeks before participating
+6. Start by helping, not promoting
 
-- **12.1.a** Read the [Code of Conduct](./Code_of_Conduct.md)
-- **12.1.b** Read the [Community Guidelines](./Community_Guidelines.md)
-- **12.1.c** Complete your Slack profile with company info
-- **12.1.d** Introduce yourself in #introductions (mention your company)
-- **12.1.e** Observe conversations for a few weeks before participating
-- **12.1.f** Start by helping, not promoting
-
-### 12.2 For Questions
-
-- **12.2.a** **General vendor questions:** DM any Admin
-- **12.2.b** **Partnership opportunities:** board@macadmins.org
-- **12.2.c** **Sponsorship inquiries:** board@macadmins.org
-- **12.2.d** **Policy clarification:** admin@macadmins.org
+**For Questions**
+- **General vendor questions:** DM any Admin
+- **Partnership opportunities:** board@macadmins.org
+- **Sponsorship inquiries:** board@macadmins.org
+- **Policy clarification:** admin@macadmins.org
 
 ## 13. Reporting Vendor Violations
 
 If you experience vendor behavior that violates this policy:
 
-- **13.a** **Contact an Admin** via DM (see #announce for current list)
-- **13.b** **Use @admins** for urgent issues
-- **13.c** **Email:** admin@macadmins.org
-- **13.d** **Provide:**
-  - Vendor username and company
-  - Description of violation
-  - Links to messages or screenshots
-  - Whether it's ongoing
+1. **Contact an Admin** via DM (see #announce for current list)
+2. **Use @admins** for urgent issues
+3. **Email:** admin@macadmins.org
+4. **Provide:**
+   - Vendor username and company
+   - Description of violation
+   - Links to messages or screenshots
+   - Whether it's ongoing
 
 See [Code of Conduct](./Code_of_Conduct.md) for full reporting procedures.
 
@@ -495,35 +439,26 @@ Admin runbooks are available for handling vendor violations including identity v
 
 ## 15. Examples
 
-### 15.1 Good Vendor Participation
+**Good Vendor Participation**
 
-**Example 15.1.a - Technical Channel:**
 > **Vendor in #jamf:** "We've seen this error come up when the client cert expires. Check your MDM logs for SSL errors. Here's our doc on troubleshooting: [link]. Happy to dig deeper if that doesn't help."
 
-**Example 15.1.b - Blog Posts:**
 > **Vendor in #blog-posts:** "I wrote up our team's approach to zero-touch DEP deployment. Thought it might be useful even if you're not using our product: [link]. Would love feedback! (Disclosure: I work for VendorCo)"
 
-**Example 15.1.c - Vendor Announce:**
 > **Vendor in #vendor-announce:** "Excited to announce VendorCo 2.0 with native Apple Silicon support and zero-touch enrollment. Built specifically for Mac admins based on community feedback. Details: [link]"
 
-**Example 15.1.d - Social Channel:**
 > **Vendor in social channel:** "Anyone else watching the game tonight?"
 
-### 15.2 Bad Vendor Participation
+**Bad Vendor Participation**
 
-**Example 15.2.a - Unsolicited Promotion:**
 > **Vendor in #mdm:** "Tired of [Competitor] problems? Switch to [OurProduct] and save 30%! DM me for a demo."
 
-**Example 15.2.b - Spam:**
 > **Vendor in multiple channels:** "[link to our product] [link to our product] [link to our product]"
 
-**Example 15.2.c - Cold DM:**
 > **Vendor via DM (unsolicited):** "Hi, I saw you're working on [topic]. We have a solution that could help. When can we set up a 30-minute demo?"
 
-**Example 15.2.d - Competitor Bashing:**
 > **Vendor in #jamf:** "Yeah, we looked at Jamf but went with [OurProduct] instead. Jamf has too many issues and their support is terrible."
 
-**Example 15.2.e - Missing Required Info:**
 > **Vendor in #jobs-board:** "Hiring Mac Admin in San Francisco" (Missing legally required salary range for CA)
 
 ## 16. Version History
@@ -531,7 +466,7 @@ Admin runbooks are available for handling vendor violations including identity v
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | 2025-10-03 | Initial vendor policy |
-| 1.1 | 2025-11-26 | Added comprehensive section and item numbering for easy reference |
+| 1.1 | 2025-11-26 | Added section numbering for easy reference |
 
 ---
 


### PR DESCRIPTION
The previous numbering was over the top - every bullet had numbers like "6.2.a", "6.2.b" which clutters the documents and isn't useful. Nobody would say "You forgot item 6.2.d" when they could say "include usernames."

This keeps the useful section numbering (Section 6.2 "What to Include") while restoring normal bullet points for list items. Much cleaner and more readable.