### PR TITLE
Add clickable section links for cross-references

### DIFF
--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -37,7 +37,7 @@
 
 ---
 
-## 1. Purpose
+## [1. Purpose](#1-purpose)
 
 The Mac Admins Slack is a global community for professionals managing Apple devices. For more than ten years, it has provided a common space for people throughout the globe to connect with each other, solve problems, and learn new technologies. This place has provided common ground for Mac Admins, vendors, Apple, and other interested parties to work on problems, devise solutions, talk through challenges, and build new workflows.
 
@@ -45,7 +45,7 @@ The coordination of this place has long depended on the community's openness to 
 
 This Code of Conduct ensures our workspace remains welcoming, professional, and productive for all members.
 
-## 2. Scope
+## [2. Scope](#2-scope)
 
 The scope of this agreement is very broad, because this community is very broad. This Code of Conduct document is intended to be clear for all the people reading and all who are part of this community.
 
@@ -56,7 +56,7 @@ This Code of Conduct applies to:
 - Direct messages between members
 - Any workspace communication or interaction
 
-## 3. Our Commitment
+## [3. Our Commitment](#3-our-commitment)
 
 The Mac Admins Foundation has a clear obligation to keep the Mac Admins Slack a safe and open community. This is designed to welcome new members, encourage collaboration in our global community, and provide psychological safety for our members.
 
@@ -75,7 +75,7 @@ We are committed to providing a harassment-free, professional environment for ev
 - Professional experience level
 - Educational background
 
-## 4. Expected Behavior
+## [4. Expected Behavior](#4-expected-behavior)
 
 All community members are expected to:
 
@@ -87,7 +87,7 @@ All community members are expected to:
 - Show empathy toward other community members
 - Credit others' work and ideas appropriately
 
-## 5. Unacceptable Behavior
+## [5. Unacceptable Behavior](#5-unacceptable-behavior)
 
 The following behaviors are not tolerated:
 
@@ -105,7 +105,7 @@ The following behaviors are not tolerated:
 - Scraping, harvesting, or collecting member data without authorization (including email addresses, usernames, profiles, or workspace metadata)
 - Any conduct that creates a hostile, intimidating, or exclusionary environment for community members (including sustained patterns of behavior that may individually seem minor but collectively undermine community safety)
 
-## 6. Reporting
+## [6. Reporting](#6-reporting)
 
 ### 6.1 How to Report
 
@@ -141,7 +141,7 @@ When reporting, please provide:
 - **No retaliation:** Reporting in good faith will not result in negative consequences
 - **Updates:** You'll be informed of the outcome when appropriate
 
-## 7. Enforcement
+## [7. Enforcement](#7-enforcement)
 
 ### 7.1 Violation Levels
 
@@ -199,7 +199,7 @@ For repeated violations:
 
 **Note:** Severe violations skip progressive discipline and result in immediate permanent ban.
 
-## 8. Appeals
+## [8. Appeals](#8-appeals)
 
 ### 8.1 Appealing Enforcement Actions
 
@@ -236,7 +236,7 @@ If you believe an Admin has violated this Code of Conduct or abused their positi
 
 Community members may also petition the MAF Board for admin removal by emailing board@macadmins.org with supporting evidence and community feedback.
 
-## 9. Admin Responsibilities
+## [9. Admin Responsibilities](#9-admin-responsibilities)
 
 Admins are responsible for:
 
@@ -266,7 +266,7 @@ Admins who do not follow or enforce this Code of Conduct, or who abuse their pos
 
 The MAF Board has authority to determine appropriate consequences based on the severity and nature of the misconduct.
 
-## 10. Scope of Admin Authority
+## [10. Scope of Admin Authority](#10-scope-of-admin-authority)
 
 Admins have the authority to:
 
@@ -277,7 +277,7 @@ Admins have the authority to:
 
 Admin decisions can be appealed to MAF leadership through the [appeals process](#8-appeals).
 
-## 11. Privacy and Data Retention
+## [11. Privacy and Data Retention](#11-privacy-and-data-retention)
 
 **Important:** Members should be aware of the following data practices:
 
@@ -291,14 +291,14 @@ Admin decisions can be appealed to MAF leadership through the [appeals process](
 
 For more details, see [Section 10: Data and Privacy](./Community_Guidelines.md#10-data-and-privacy) in the Community Guidelines.
 
-## 12. Additional Policies
+## [12. Additional Policies](#12-additional-policies)
 
 This Code of Conduct is supplemented by:
 
 - [Community Guidelines](./Community_Guidelines.md) - Detailed expectations and best practices
 - [Vendor Policy](./Vendor_Policy.md) - Rules for vendor participation and promotional content
 
-## 13. Modifications
+## [13. Modifications](#13-modifications)
 
 This Code of Conduct may be updated at any time. Changes will be:
 
@@ -307,7 +307,7 @@ This Code of Conduct may be updated at any time. Changes will be:
 - Effective 30 days after announcement (for major changes)
 - Archived versions available for reference
 
-## 14. Attribution
+## [14. Attribution](#14-attribution)
 
 This Code of Conduct is adapted from:
 
@@ -315,17 +315,17 @@ This Code of Conduct is adapted from:
 - The Django Code of Conduct
 - Previous Mac Admins Slack Code of Conduct (v1.0)
 
-## 15. License
+## [15. License](#15-license)
 
 This Code of Conduct is released under Creative Commons CC BY 4.0.
 
-## 16. Contact
+## [16. Contact](#16-contact)
 
 - **Admin Team:** admin@macadmins.org or @admins in Slack
 - **MAF Board:** board@macadmins.org
 - **Website:** https://www.macadmins.org
 
-## 17. Acknowledgment
+## [17. Acknowledgment](#17-acknowledgment)
 
 By participating in The Mac Admins Slack, you agree to abide by this Code of Conduct.
 
@@ -333,7 +333,7 @@ By participating in The Mac Admins Slack, you agree to abide by this Code of Con
 
 **Thank you for helping make The Mac Admins Slack a welcoming, respectful, and professional community.**
 
-## 18. Revision History
+## [18. Revision History](#18-revision-history)
 
 | Version | Date | Changes |
 |---------|------|---------|
@@ -342,3 +342,4 @@ By participating in The Mac Admins Slack, you agree to abide by this Code of Con
 | 2.1 | 2025-10-10 | Minor revision: Included more narrative language |
 | 3.0 | 2025-11-26 | Added section numbering for easy reference |
 | 3.1 | 2025-11-26 | Added clickable section links for cross-references |
+| 3.2 | 2025-11-26 | Made section headings clickable for easy link sharing |

--- a/Community_Guidelines.md
+++ b/Community_Guidelines.md
@@ -49,11 +49,11 @@
 
 ---
 
-## 1. Purpose
+## [1. Purpose](#1-purpose)
 
 These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md) with practical guidance for participating in The Mac Admins Slack. While the Code of Conduct defines what is not acceptable, these guidelines describe what good community participation looks like.
 
-## 2. Getting Started
+## [2. Getting Started](#2-getting-started)
 
 ### 2.1 Joining the Workspace
 
@@ -74,7 +74,7 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
 
 **Privacy note:** Only share what you're comfortable making public.
 
-## 3. Communication Best Practices
+## [3. Communication Best Practices](#3-communication-best-practices)
 
 ### 3.1 General Guidelines
 
@@ -136,7 +136,7 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
 - Invite Admin mediation if needed
 - Remember: being right isn't worth being rude
 
-## 4. Channel Etiquette
+## [4. Channel Etiquette](#4-channel-etiquette)
 
 ### 4.1 Public Channels
 
@@ -184,7 +184,7 @@ Some channels have specific posting and discussion patterns:
 - Don't use DMs to bypass channel guidelines (e.g., unsolicited sales)
 - Report inappropriate DMs to Admins
 
-## 5. Vendor and Commercial Participation
+## [5. Vendor and Commercial Participation](#5-vendor-and-commercial-participation)
 
 See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Summary:
 
@@ -202,7 +202,7 @@ See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Su
 - Disparaging competitors
 - Recruiting without Admin approval
 
-## 6. Content Sharing
+## [6. Content Sharing](#6-content-sharing)
 
 ### 6.1 Links and Resources
 
@@ -245,7 +245,7 @@ See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Su
 - Don't share recordings of Slack calls externally
 - Admin team may record calls for training purposes (with notice)
 
-## 7. Accessibility and Inclusion
+## [7. Accessibility and Inclusion](#7-accessibility-and-inclusion)
 
 ### 7.1 Making Content Accessible
 
@@ -270,7 +270,7 @@ See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Su
 - Assume good intent
 - Offer clarification without judgment
 
-## 8. Topics to Approach Carefully
+## [8. Topics to Approach Carefully](#8-topics-to-approach-carefully)
 
 ### 8.1 Generally Acceptable (But Be Respectful)
 
@@ -311,7 +311,7 @@ See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Su
 - Legal advice (we're not lawyers)
 - Medical advice (we're not doctors)
 
-## 9. Bots and Automation
+## [9. Bots and Automation](#9-bots-and-automation)
 
 Only MAF-approved bots are enabled in the workspace. User bots and custom integrations are not permitted.
 
@@ -319,7 +319,7 @@ Only MAF-approved bots are enabled in the workspace. User bots and custom integr
 - Use built-in Slack commands appropriately
 - Report malfunctioning bots to Admins
 
-## 10. Data and Privacy
+## [10. Data and Privacy](#10-data-and-privacy)
 
 ### 10.1 Your Data
 
@@ -344,7 +344,7 @@ Only MAF-approved bots are enabled in the workspace. User bots and custom integr
 - Data access is logged and auditable
 - Admin Runbooks available for admins
 
-## 11. Recognition and Credit
+## [11. Recognition and Credit](#11-recognition-and-credit)
 
 **Giving Credit**
 - Credit others' work and ideas
@@ -357,7 +357,7 @@ Only MAF-approved bots are enabled in the workspace. User bots and custom integr
 - Acknowledge collaborators
 - Share the spotlight
 
-## 12. When Things Go Wrong
+## [12. When Things Go Wrong](#12-when-things-go-wrong)
 
 ### 12.1 If You Made a Mistake
 
@@ -380,14 +380,14 @@ Only MAF-approved bots are enabled in the workspace. User bots and custom integr
 - Ask questions if you don't understand
 - Accept the outcome gracefully (or use the [appeals process](./Code_of_Conduct.md#8-appeals))
 
-## 13. Resources
+## [13. Resources](#13-resources)
 
 - [Code of Conduct](./Code_of_Conduct.md) - What's not acceptable
 - [Vendor Policy](./Vendor_Policy.md) - Guidelines for vendors
 - [Admin Channels](./admin-channels.md) - How to contact Admins
 - [Escalation Matrix](./escalation-matrix.md) - How Admins handle issues
 
-## 14. Getting Help
+## [14. Getting Help](#14-getting-help)
 
 **Technical Help**
 - Post in relevant technical channels
@@ -403,7 +403,7 @@ Only MAF-approved bots are enabled in the workspace. User bots and custom integr
 - #macadminsfoundation channel
 - board@macadmins.org
 
-## 15. Contributing to These Guidelines
+## [15. Contributing to These Guidelines](#15-contributing-to-these-guidelines)
 
 These guidelines evolve based on community needs. To suggest improvements:
 
@@ -411,7 +411,7 @@ These guidelines evolve based on community needs. To suggest improvements:
 2. Discuss in #macadminsfoundation
 3. Contact an Admin or MAF Board member
 
-## 16. Final Thoughts
+## [16. Final Thoughts](#16-final-thoughts)
 
 The Mac Admins Slack exists because thousands of professionals choose to spend their time helping each other. These guidelines help ensure the community remains valuable, welcoming, and sustainable.
 
@@ -421,10 +421,11 @@ Welcome to The Mac Admins Slack!
 
 ---
 
-## 17. Revision History
+## [17. Revision History](#17-revision-history)
 
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | 2025-10-03 | Initial community guidelines |
 | 1.1 | 2025-11-26 | Added section numbering for easy reference |
 | 1.2 | 2025-11-26 | Added clickable section links for cross-references |
+| 1.3 | 2025-11-26 | Made section headings clickable for easy link sharing |

--- a/Vendor_Policy.md
+++ b/Vendor_Policy.md
@@ -41,11 +41,11 @@
 
 ---
 
-## 1. Purpose
+## [1. Purpose](#1-purpose)
 
 The Mac Admins Slack welcomes vendors as community members. This policy clarifies expectations for vendor participation to ensure vendors contribute value while maintaining the community's focus on authentic peer-to-peer knowledge sharing.
 
-## 2. Scope
+## [2. Scope](#2-scope)
 
 This policy applies to:
 
@@ -55,7 +55,7 @@ This policy applies to:
 - Service providers
 - Anyone with commercial interests in products/services relevant to Mac administration
 
-## 3. Philosophy
+## [3. Philosophy](#3-philosophy)
 
 **We welcome vendors who:**
 - Participate authentically as community members
@@ -69,7 +69,7 @@ This policy applies to:
 - Astroturfing or fake testimonials
 - Competitor disparagement
 
-## 4. Vendor Participation Guidelines
+## [4. Vendor Participation Guidelines](#4-vendor-participation-guidelines)
 
 ### 4.1 Acceptable Vendor Behavior
 
@@ -138,7 +138,7 @@ This policy applies to:
 - Headhunting without Admin approval
 - Aggressive talent recruitment
 
-## 5. Channel-Specific Guidelines
+## [5. Channel-Specific Guidelines](#5-channel-specific-guidelines)
 
 ### 5.1 Technical Channels (#mac, #ios, #jamf, etc.)
 
@@ -238,7 +238,7 @@ This policy applies to:
 - Off-topic chat is welcome
 - Don't turn social conversations into sales opportunities
 
-## 6. Direct Messages (DMs)
+## [6. Direct Messages (DMs)](#6-direct-messages-dms)
 
 ### 6.1 Acceptable DM Use
 
@@ -267,7 +267,7 @@ This policy applies to:
 - Don't ask "why not"
 - Move on gracefully
 
-## 7. Special Circumstances
+## [7. Special Circumstances](#7-special-circumstances)
 
 ### 7.1 Sponsored Content
 
@@ -312,7 +312,7 @@ If two vendors from competing companies have a disagreement:
 - Involve Admins if needed
 - Remember: you're representing your company
 
-## 8. Identity Verification for Vendors
+## [8. Identity Verification for Vendors](#8-identity-verification-for-vendors)
 
 Admins may request verification of vendor identity to ensure authenticity and prevent impersonation.
 
@@ -333,7 +333,7 @@ Admins may request verification of vendor identity to ensure authenticity and pr
 
 Verification is not required for all vendors—only when authenticity concerns arise or for vendors with significant community presence.
 
-## 9. Enforcement
+## [9. Enforcement](#9-enforcement)
 
 Vendor policy violations are handled according to the [Code of Conduct enforcement procedures](./Code_of_Conduct.md#7-enforcement):
 
@@ -357,7 +357,7 @@ Vendor policy violations are handled according to the [Code of Conduct enforceme
 - Possible escalation to legal (for harassment, doxxing, etc.)
 - Notification to other communities if relevant
 
-## 10. Vendor Benefits
+## [10. Vendor Benefits](#10-vendor-benefits)
 
 Vendors who follow these guidelines and participate authentically receive:
 
@@ -381,7 +381,7 @@ Vendors who follow these guidelines and participate authentically receive:
 - Organic recruiting opportunities
 - Industry reputation building
 
-## 11. Best Practices for Vendors
+## [11. Best Practices for Vendors](#11-best-practices-for-vendors)
 
 **Do's**
 - Complete your profile with company affiliation
@@ -402,7 +402,7 @@ Vendors who follow these guidelines and participate authentically receive:
 - Bad-mouth competitors
 - Track community sentiment for competitive advantage without giving back
 
-## 12. Vendor Resources
+## [12. Vendor Resources](#12-vendor-resources)
 
 **For New Vendors**
 1. Read the [Code of Conduct](./Code_of_Conduct.md)
@@ -418,7 +418,7 @@ Vendors who follow these guidelines and participate authentically receive:
 - **Sponsorship inquiries:** board@macadmins.org
 - **Policy clarification:** admin@macadmins.org
 
-## 13. Reporting Vendor Violations
+## [13. Reporting Vendor Violations](#13-reporting-vendor-violations)
 
 If you experience vendor behavior that violates this policy:
 
@@ -433,11 +433,11 @@ If you experience vendor behavior that violates this policy:
 
 See [Code of Conduct Section 6: Reporting](./Code_of_Conduct.md#6-reporting) for full reporting procedures.
 
-## 14. For Admins
+## [14. For Admins](#14-for-admins)
 
 Admin runbooks are available for handling vendor violations including identity verification, spam handling, and member suspension procedures.
 
-## 15. Examples
+## [15. Examples](#15-examples)
 
 **Good Vendor Participation**
 
@@ -461,13 +461,14 @@ Admin runbooks are available for handling vendor violations including identity v
 
 > **Vendor in #jobs-board:** "Hiring Mac Admin in San Francisco" (Missing legally required salary range for CA)
 
-## 16. Version History
+## [16. Version History](#16-version-history)
 
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | 2025-10-03 | Initial vendor policy |
 | 1.1 | 2025-11-26 | Added section numbering for easy reference |
 | 1.2 | 2025-11-26 | Added clickable section links for cross-references |
+| 1.3 | 2025-11-26 | Made section headings clickable for easy link sharing |
 
 ---
 


### PR DESCRIPTION
Make in-text section references clickable so users can navigate directly to referenced sections. This improves document usability by making it easy to jump to related content when mentioned.