### PR TITLE
Update Community_Guidelines.md, Sections 3 and 4 (partial)

### DIFF
--- a/Community_Guidelines.md
+++ b/Community_Guidelines.md
@@ -86,101 +86,113 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
 - Use formatting (bold, code blocks) appropriately
 - Search before asking - your question may be answered already
 
-**Be Respectful of Time**
+**Be Respectful of Others' Time and Availability**
 
-- Use @admins only for urgent admin matters
-- Respect "do not disturb" and timezone differences
-- Be patient waiting for responses - this is an async community
+- A user's activity status and local time can be seen in their Slack profile; click or tap their username to check it.
+- The MacAdmins Slack is an asynchronous community; replies may take several minutes, hours, days, or even weeks.
+- Respect others' "do not disturb" settings and timezone differences.
+- The Slack admins are volunteers with no SLA or guaranteed response time, but will do their best to respond as quickly as possible
+- Only tag the @admins for truly urgent matters.
 
 **Be Inclusive**
 
-- Remember this is a global community with varying English proficiency
-- Avoid idioms and cultural references that may not translate
-- Be patient with misunderstandings
-- Offer clarification when asked
+- English is the primary language on this Slack instance; however, this is a worldwide community with members whose native language is not English.
+- Avoid idioms and cultural references that might not translate clearly.
+- Offer clarification when asked.
+- Ask for clarification if something is unclear.   
+- In case of a misunderstanding, be patient.
+- Assume positive intent.
 
 ### 3.2 Technical Discussions
 
 **Asking Questions**
 
-- Search Slack history first
-- Jump in and ask your question, there's no need to "ask to ask"
-- Provide context (OS version, device model, MDM, etc.)
-- Include error messages or logs (use snippets for long text)
-- Post in the most relevant channel
+- Use the Search feature in Slack before asking questions; yours might already be answered.
+- Find and join a channel that is most relevant to your issue.
+- Jump in and ask your question; there's no need to ask permission to ask a question.
+- Provide sufficient context for the issue (e.g.: OS version, device type, MDM solution, etc.)
+- Include relevant error messages and/or logs
+- For longer log excerpts more than a few lines, please create a "text snippet" instead.
 - Share what you've already tried so we can help more effectively
-- Update the thread if you solve your own problem
+- The discussion might become threaded as replies or follow-up questions come in.
+- Update the thread if you solve your own problem.
 
 **Answering Questions**
 
-- Be kind - everyone was new once
-- Explain your reasoning, don't just post commands
-- Link to documentation when relevant
-- If you're unsure, say so
-- Follow the channel's threading conventions
+- Be kind.  Remember: everyone was once a beginner.
+- Explain your reasoning; avoid posting commands or solutions without context.
+- Link to documentation when relevant.
+- It's ok to say "I don't know."
+- Follow the channel's threading conventions.
 
 **Sharing Solutions**
 
-- Share code snippets as files or formatted code blocks
-- Sanitize private information
-- Include comments in scripts
-- Explain any prerequisites or caveats
-- Link to GitHub repos for longer code
-- Credit original authors if adapting their work
+- Share code snippets as files, formatted code blocks, or text snippets
+- Sanitize, obfuscate, or make generic any information that could be private or sensitive (e.g.: passwords, access keys, file paths, usernames, etc.)
+- Include comments in scripts.
+- Explain any prerequisites, caveats, gotchas, etc.
+- For large amounts of code, such as a project, we suggest creating a free Github repository and linking to that instead.
+- If you borrow or adapt someone else's work, give them credit or attribution.
 
 ### 3.3 Debates and Disagreements
 
 **Healthy Debate**
 
-- Focus on ideas, not people
-- Use "I" statements: "I've found..." not "You're wrong..."
-- Acknowledge valid points
-- Know when to agree to disagree
-- Consider moving heated discussions to DM
+- Debate is an academic activity for finding solutions by critiquing ideas, not criticizing people.
+- When necessary to point out a flaw, say something constructive ("I've found a problem," or "This seems to be incorrect") instead of accusing the person ("You're wrong because...")
+- Acknowledge valid points within the debate.
+- Know when to agree to disagree, and move on.
+- If the discussion becomes heated in a channel, please use direct messages to work out the disagreement.
 
 **When Tensions Rise**
 
-- Take a break before responding
-- Assume good intent, but remember that impact matters regardless of intent—take responsibility if your words cause harm
-- Ask clarifying questions
-- Invite Admin mediation if needed
-- Remember: being right isn't worth being rude
+- Take a break before responding.
+- Assume positive intent, but remember that impact matters regardless of intent.
+- Take responsibility if the other person tells you that your words caused harm.
+- Ask clarifying questions.
+- Invite an admin to mediate a discussion only as a last resort.
+- Remember: being right isn't worth being rude.
 
 ## [4. Channel Etiquette](#4-channel-etiquette)
 
 ### 4.1 Public Channels
 
-**On-Topic Conversations**
+**Keeping Conversations On-Topic**
 
-- Read channel descriptions and topics
-- Stay generally on-topic
-- Ask Admins if you're unsure where to post
-- Use #random for off-topic chat
+- Read channel descriptions and topics when joining.
+- Stay generally on-topic.
+- If you're unsure where to post or find discussion of an issue, ask in the #general channel.
+- For truly off-topic chat, please use the #breakroom channel.
+- Note: there may be private channels with special interests that require invitation by an existing member; the Slack admins cannot add you to them, and will not suggest any when asked.
+- Warning: even in the off-topic and private channels, Rule 3.3 still applies.
 
 **Cross-Posting**
 
-- Avoid posting the same question in multiple channels
-- If you must cross-post, mention where else you've posted
-- Don't tag multiple people with the same question
+- Avoid posting the same question in multiple channels.
+- If you must cross-post, mention where else you've posted.
+- Don't tag multiple people with the same question.
 
 **Reactions and Emoji**
 
-- Use reactions instead of "+1" messages
-- Common reactions:
-  - ✅ = solved/resolved
-  - 👀 = I'm looking into this
-  - 🙏 = thank you
-  - 📝 = documented/noted
+- To avoid cluttering channels with "me too" or "+1" messages, use Slack reactions ("reacji") to indicate your response or feeling about a message.
+- Examples of common reactions:
+  - 👍 = yes, agree, understood, thanks
+  - ✅ = yes, accepted
+  - 🚫 = no, rejected
+  - 👀 = surprised, very interested, looking into this
+  - 🙏 = high praise, thank you very much
+  - 📝 = noted or documented
 
 **Special Channel Structures**
 
 Some channels have specific posting and discussion patterns:
 
-- **#appleseed** - Discussion of Apple Seed programs and beta testing
-- **#apple-feedback** - Coordinating Apple feedback submissions
-- **#jamf-product-issues** - Jamf-specific product issues and troubleshooting
-- **#blog-feed / #blog-chat** - Blog posts appear in #blog-feed, discussion happens in #blog-chat
-- **#jobs-board / #jobs-chat** - Job postings go in #jobs-board, discussion happens in #jobs-chat. Threaded replies on specific job postings are fine, but general chatter moves to #jobs-chat. Salary disclosure encouraged for all postings but required where legally mandated (CA, CO, NYC, etc.)
+- **#appleseed**: Discussion of Apple Seed programs and beta testing
+- **#apple-feedback**: Coordinating Apple feedback submissions
+- **#jamf-product-issues**: Jamf-specific product issues and troubleshooting
+- **#blog-feed / #blog-chat**: Blog posts appear in #blog-feed, discussion happens in #blog-chat
+- **#jobs-board**: members in this channel are actively looking for work and will enable notifications for all new messages.  To minimize noise and distraction, messages in the main channel are limited to job postings only; discussion about a particular job MUST be a threaded reply.  We encourage salaries to be posted in all cases; however, they MUST be posted in the channel where required by law (e.g.: CA, CO, NYC, some European countries, etc.).  Failure to disclose required salary information may result in the message being removed.
+-  **#jobs-chat**: this channel is reserved for general discussion about the job market, a particular industry or employer, the general economy, or anything pertaining thereto.  Note: keep politically-oriented conversation to a minimum.
 - **#politics** - There is a private politics channel. To request access, see the placeholder #politics channel and DM an Admin.
 
 ### 4.2 Direct Messages

--- a/Community_Guidelines.md
+++ b/Community_Guidelines.md
@@ -11,13 +11,15 @@
 - [2. Getting Started](#2-getting-started)
   - [2.1 Joining the Workspace](#21-joining-the-workspace)
   - [2.2 Setting Up Your Profile](#22-setting-up-your-profile)
+  - [2.3 Full Name vs. Display Name](#23-full-name-vs-display-name)
 - [3. Communication Best Practices](#3-communication-best-practices)
   - [3.1 General Guidelines](#31-general-guidelines)
   - [3.2 Technical Discussions](#32-technical-discussions)
   - [3.3 Debates and Disagreements](#33-debates-and-disagreements)
 - [4. Channel Etiquette](#4-channel-etiquette)
   - [4.1 Public Channels](#41-public-channels)
-  - [4.2 Direct Messages](#42-direct-messages)
+  - [4.2 Special Channels](#42-special-channels)
+  - [4.3 Direct Messages](#43-direct-messages)
 - [5. Vendor and Commercial Participation](#5-vendor-and-commercial-participation)
 - [6. Content Sharing](#6-content-sharing)
   - [6.1 Links and Resources](#61-links-and-resources)
@@ -28,7 +30,7 @@
   - [7.2 Language and Communication](#72-language-and-communication)
   - [7.3 Neurodiversity](#73-neurodiversity)
 - [8. Topics to Approach Carefully](#8-topics-to-approach-carefully)
-  - [8.1 Generally Acceptable (But Be Respectful)](#81-generally-acceptable-but-be-respectful)
+  - [8.1 Generally Acceptable](#81-generally-acceptable)
   - [8.2 Requires Caution](#82-requires-caution)
   - [8.3 Not Appropriate for This Workspace](#83-not-appropriate-for-this-workspace)
 - [9. Bots and Automation](#9-bots-and-automation)
@@ -51,40 +53,84 @@
 
 ## [1. Purpose](#1-purpose)
 
-These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md) with practical guidance for participating in The Mac Admins Slack. While the Code of Conduct defines what is not acceptable, these guidelines describe what good community participation looks like.
+The Community Guidelines are a **supplement** to the [Code of Conduct](./Code_of_Conduct.md), and contain practical guidance to get the most out of your membership in the MacAdmins Slack.  Think of this document like a book of manners, or an etiquette guide for this networked space ("netiquette").
 
 ## [2. Getting Started](#2-getting-started)
 
-### 2.1 Joining the Workspace
+### 2.1 Joining the Workspace(#21-joining-the-workspace)
 
-- Read and understand the [Code of Conduct](./Code_of_Conduct.md)
-- Complete your profile with your name and role (optional but encouraged)
-- Introduce yourself in #introductions
-- Browse channel descriptions to find relevant discussions
+- Read and understand the [Code of Conduct](./Code_of_Conduct.md).
+- Complete your Slack profile; see [Section 2.2](#22-setting-up-your-profile) below.
+- Browse and search the channel list to find relevant spaces for discussion.
 
-### 2.2 Setting Up Your Profile
+### 2.2 Setting Up Your Profile(#22-setting-up-your-profile)
 
-**Recommended profile information:**
+When you registered for the MacAdmins Slack, you used an email address to sign up.  If you need to change this email address later, you must contact an administrator for assistance.
 
-- Full name (or preferred name)
-- Current role and organization (optional)
-- Pronouns (optional)
-- Time zone (helpful for async communication)
-- Profile photo (optional)
+Slack will ask you to enter information into your Slack profile. 
 
-**Privacy note:** Only share what you're comfortable making public.
+Required Field: [Full Name](#23a-about-the-full-name)
+
+Optional Fields:
+- [Display Name](#23b-about-the-display-name)
+- Title
+- Pronouns
+- Name Pronunciation
+- Phone Number
+
+Other fields (available on Slack desktop app or via web browser)
+- Github
+- LinkedIn
+- Blog
+- Twitter
+- Other Sites
+
+### 2.3 Full Name vs. Display Name(#23-full-name-vs-display-name)
+
+Slack allows users to decide whether they want to see messages displayed with a user's full name, or their display name.
+
+**[Full Name](#23a-about-the-full-name)**
+
+This field cannot be empty.  It is a global rule that applies to ALL Slack instances, not just the MacAdmins Slack.
+
+**[Display Name](#23b-about-the-display-name)**
+
+Treat this field like a username, shortname, handle, or alias.  
+
+**Privacy Considerations**
+
+If you do not wish to disclose your real name, you are free to put anything you want in the Full Name field.  
+
+The MacAdmins Slack does not perform identity verification, and pseudonyms are allowed.  Having said that, we encourage you to use your real name to establish trust and facilitate networking with your peers.
+
+If users decide to show display names instead of full names, they will see your display name if it is set.  Otherwise, they will always see whatever is in the "Full Name" field.
 
 ## [3. Communication Best Practices](#3-communication-best-practices)
 
+**A Brief History of Slack**
+
+Slack was created in 2012, and initially designed to mimic the experience of the old Internet Relay Chat system from the 1990s.  The acronym "S.L.A.C.K." stands for "Searchable Log of All Conversation and Knowledge."  Search is arguably the single most powerful feature of Slack.  
+
+**Lurking and Observing Slack Culture**
+
+As Slack has evolved over time to add features that facilitate workplace collaboration, its has garned a devoted following of millions of users.  People have grown to use Slack in a variety of ways that were influenced by their life experiences, their exposure to the internet and especially IRC, or their workplace's culture and attitude toward Slack and office collaboration tools.
+
+The MacAdmins Slack was created in mid-2015.  In long-running community spaces, certain behaviors and preferences established by the earliest members become an integral part of that community's heritage, and tend to dictate certain cultural norms.  You will find echoes of these cultural norms across the instance.
+
 ### 3.1 General Guidelines
 
-**Be Clear and Concise**
+As in any society, new members would be wise to "lurk" for a bit and observe how the community runs.  As a member, you are free to join as many or as few channels as you like.  You can scroll back to the beginning, or just catch up on what happened last week.
 
-- Threading varies by channel - most channels don't thread as we predate that feature
-- Observe channel norms before posting
-- Break long messages into paragraphs
-- Use formatting (bold, code blocks) appropriately
-- Search before asking - your question may be answered already
+Here are some general norms to observe in the Slack instance:
+
+**Be Considerate and Thoughtful**
+
+- Always use the Search feature before posting; your question may already have been answered.
+- Nesting replies into threads varies by channel; some insist on it; others do not care.
+- Avoid posting short messages in rapid-fire succession; Slack is not a text messaging service.
+- Use formatting as desired for **emphasis**, or to distinguishe `code` from text, or ~~strikeout~~ other text.
+- If you make a mistake, you can edit your own messages up to 30 minutes after posting.
+- Break long messages into shorter paragraphs as necessary.
 
 **Be Respectful of Others' Time and Availability**
 
@@ -102,6 +148,8 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
 - Ask for clarification if something is unclear.   
 - In case of a misunderstanding, be patient.
 - Assume positive intent.
+- Consider accessibility when writing: your message may be read on a mobile phone, a tablet, a computer, or even a screen reader.
+
 
 ### 3.2 Technical Discussions
 
@@ -183,61 +231,68 @@ These Community Guidelines supplement our [Code of Conduct](./Code_of_Conduct.md
   - 🙏 = high praise, thank you very much
   - 📝 = noted or documented
 
-**Special Channel Structures**
+### [4.2 Special Channels](#42-special-channels)**
 
-Some channels have specific posting and discussion patterns:
+Some channels have specific posting and discussion patterns.  Please be careful to observe their rules and customs before posting.  NOTE: this list is not exhaustive.
 
-- **#appleseed**: Discussion of Apple Seed programs and beta testing
-- **#apple-feedback**: Coordinating Apple feedback submissions
-- **#jamf-product-issues**: Jamf-specific product issues and troubleshooting
-- **#blog-feed / #blog-chat**: Blog posts appear in #blog-feed, discussion happens in #blog-chat
-- **#jobs-board**: members in this channel are actively looking for work and will enable notifications for all new messages.  To minimize noise and distraction, messages in the main channel are limited to job postings only; discussion about a particular job MUST be a threaded reply.  We encourage salaries to be posted in all cases; however, they MUST be posted in the channel where required by law (e.g.: CA, CO, NYC, some European countries, etc.).  Failure to disclose required salary information may result in the message being removed.
+- **#appleseed**: This channel is used to join the AppleSeed for IT private beta channel.  Read the rules and contact one of the coordinators to be invited to the private channel.
+- **#apple-feedback**: This channel may be used to Coordinate Apple feedback submissions (formerly bug reports).
+- **#jamf-product-issues**: This channel is for posting Jamf Product Issues opened by support, which might not appear in the "Known Issues" page on the Jamf Account portal.
+- **#blog-feed**: this channel is powered by a Slack-integrated app called "RSS."  Blogs registered in this channel will post as soon as the author makes a submission.  The feed is self-managed by channel members, not by admins.
+- **#blog-chat**: Discussion or support for #blog-feed belongs in this channel.
+- **#jobs-board**: members in this channel are actively looking for work and will likely have notifications enabled for **all new messages**.  To minimize noise and distraction for job seekers, messages in the main channel must be limited to job postings only; any discussion or follow-up replies about a job posting MUST be a threaded reply to that message.
 -  **#jobs-chat**: this channel is reserved for general discussion about the job market, a particular industry or employer, the general economy, or anything pertaining thereto.  Note: keep politically-oriented conversation to a minimum.
-- **#politics** - There is a private politics channel. To request access, see the placeholder #politics channel and DM an Admin.
+- **#politics** - There is a private politics channel. See [Section 8.2](#82-requires-caution).
 
-### 4.2 Direct Messages
+*A note about #jobs-board: job postings may be posted by recruiters, hiring managers, employees, or even unaffiliated persons if they happen to find a great job listing and want to share it.  If the job is hiring in a jurisdiction or industry with a **legal** requirement to post the salary range (e.g.: CA, CO, NYC, parts of Europe, the public sector), then this information must be included in the job posting on Slack.  Failure to disclose required salary information **may** result in the message being removed.*
 
-**When to DM**
+### [4.2 Direct Messages](#42-direct-messages)
 
-- Sensitive topics not appropriate for public channels
-- Continuing a conversation that's gone off-topic
-- Contacting Admins about [CoC violations](./Code_of_Conduct.md#6-reporting)
-- Networking or mentorship requests (when you have an existing relationship or context from public channels)
+**When to send Direct Messages**
 
-**DM Etiquette**
+- If you need to discuss sensitive topics not appropriate for public channels.
+- Continuing a conversation that's gone too far off-topic.
+- Privately resolving a conflict with a member.  Remember to be polite and professional.
+- Contacting Admins about [Code of Conduct violations](./Code_of_Conduct.md#6-reporting)
+- Networking or mentorship requests (when you have an existing relationship or context from public channels).
 
-- Ask if someone is open to DMs before sending lengthy messages
-- Respect "no" - not everyone wants to chat privately
-- Don't use DMs to bypass channel guidelines (e.g., unsolicited sales)
-- Report inappropriate DMs to Admins
+**Etiquette**
+
+- Ask if someone is open to DMs before sending lengthy messages.
+- Respect their "no"; not all members want to chat privately.
+- If the DM suddenly makes you uncomfortable, stop replying and notify an admin.
 
 ## [5. Vendor and Commercial Participation](#5-vendor-and-commercial-participation)
 
-See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Summary:
+See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. 
 
-**✅ Acceptable:**
+Here are some general rules for vendors to follow:
 
-- Participating authentically as a community member
-- Answering technical questions about your products
-- Sharing relevant announcements in appropriate channels
-- Transparent disclosure of affiliation
+**✅ Allowed:**
 
-**❌ Not Acceptable:**
+- You may participate authentically as a community member.
+- You may answer technical questions about your products and services.
+- You may share relevant announcements in appropriate channels (e.g.: software updates, new product launches)
+- You must transparently disclose your affiliation with your vendor.
 
-- Cold-calling members via DM
-- Posting promotional content without context
-- Astroturfing (fake grassroots support) or sockpuppeting (using fake accounts to post testimonials or promote products)
-- Impersonation (including vendors/competitors posing as customers)
-- Disparaging competitors
-- Recruiting without Admin approval
+**❌ Not Allowed:**
+
+- You may not post promotional content without context.
+- You may not engage in astroturfing (generating fake grassroots support with multiple accounts).
+- You may not create sockpuppet accounts (to post testimonials or promote products).
+- You shall not send sales pitches, or recruit members via Direct Messages.
+- You shall not impersonate someone else.
+- You shall not directly recruit individuals without approval from the admins.
+- You shall not complain about a Slack member to their employer via backchannels if they are a customer.
+  You should not disparage your competitors; not only does it look unprofessional, but they're probably on this instance too, and your world as a vendor is smaller than you might realize.
 
 ## [6. Content Sharing](#6-content-sharing)
 
-### 6.1 Links and Resources
+### [6.1 Links and Resources](#61-links-and-resources)
 
-**Acceptable:**
+**OK to Share:**
 
-- Blog posts (your own or others')
+- Blog posts (your own blog, or someone else's)
 - Documentation and how-to guides
 - Open source projects
 - Conference talks and recordings
@@ -245,69 +300,71 @@ See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Su
 
 **Guidelines:**
 
-- Provide context - don't just drop links
-- Disclose if it's your own content
-- Use appropriate channels (#blog-posts, #conferences, etc.)
-- Don't link to paywalled content without mentioning it
+- Provide context; please don't just drop links into the chat.
+- Please disclose if this is your own content, or someone else's.
+- Use appropriate channels where possible (#blog-feed, conference/vendor-specific channels, etc.)
+- Avoid linking to "paywalled" content; if this is unavoidable, provide alternate means for others to read the content.
 
-### 6.2 Self-Promotion
+### [6.2 Self-Promotion](#62-self-promotion)
 
 **Allowed (in moderation):**
 
-- Sharing your blog posts in #blog-posts
-- Conference talk announcements in #conferences
-- Open source project launches in a channel related to the project
-- Job postings in #jobs-board (discussion in #jobs-chat)
+- Sharing your own blog posts.
+- Announcing your own conference talks.
+- Launching an open-source project in a relevant channel.
+- Posting a job for a role being filled at your own company.
 
 **Not Allowed:**
 
-- Repeated self-promotion
-- Off-topic promotion
-- Promotional content disguised as help
+- Repeated self-promotion.
+- Content that is not directly about the mission of this Slack instance.
+- Promotional content disguised as help.
 
-### 6.3 Screenshots and Recordings
+### [6.3 Screenshots and Recordings](#63-screenshots-and-recordings)
 
 **Privacy Considerations**
 
 - Blur or redact sensitive information (names, emails, IPs, etc.)
-- Don't share screenshots of DMs without permission
-- Don't share internal company information
-- Assume workspace conversations are public
+- Get permission before sharing screenshots.
+- Refrain from sharing internal company information; redact where possible.
+- Although Slack is not searchable from Google, anyone can join.  Treat it like a public space.
 
 **Recording Policy**
 
-- Don't record calls without consent
-- Don't share recordings of Slack calls externally
-- Admin team may record calls for training purposes (with notice)
+- Don't record calls (Huddles) without consent (varies by jurisdiction).
+- Don't share recordings of Slack calls externally.
+- The Slack admin team may record calls for training purposes (with sufficient notice given).
 
 ## [7. Accessibility and Inclusion](#7-accessibility-and-inclusion)
 
-### 7.1 Making Content Accessible
+### [7.1 Making Content Accessible](#71-making-content-accessible)
 
-- Add alt text to images when possible
-- Use descriptive link text, not "click here"
-- Follow channel threading norms
-- Avoid wall-of-text messages
-- Use headings in longer posts
+- Add alt text to images when possible.
+- Use descriptive link text, not just "click here."
+- Follow norms related to channel threading.
+- Break walls of text into smaller paragraphs.
+- Use headings in longer posts.
 
-### 7.2 Language and Communication
+### [7.2 Language and Communication](#72-language-and-communication)
 
-- Use clear, simple language
-- Define acronyms on first use
+- Use clear, simple language.
+- Define acronyms on first use.
 - Be patient with non-native English speakers
 - Avoid sarcasm - it doesn't translate well
 - Use emoji thoughtfully (some are culturally specific)
 
-### 7.3 Neurodiversity
+### [7.3 Neurodiversity](#73-neurodiversity)
 
-- Some members may communicate differently
-- Be patient with communication styles
-- Assume good intent
-- Offer clarification without judgment
+The IT field is dominated by individuals with neurodversity (ADHD, Autism, Anxiety, OCD, etc.)
+
+- Some members may communicate differently, and that's OK.
+- Be patient with different communication styles.
+- Assume positive intent.
+- Offer clarification without judgment.
 
 ## [8. Topics to Approach Carefully](#8-topics-to-approach-carefully)
 
-### 8.1 Generally Acceptable (But Be Respectful)
+### [8.1 Generally Acceptable](#81-generally-acceptable) (But Be Respectful)
 
 - Apple platform technical discussions (primary purpose)
 - IT and systems administration
@@ -315,128 +372,123 @@ See the detailed [Vendor Policy](./Vendor_Policy.md) for complete guidelines. Su
 - Conference and meetup announcements
 - Industry news relevant to Mac admins
 
-### 8.2 Requires Caution
+### [8.2 Requires Caution](#82-requires-caution)
 
 **Politics**
 
-- There is a private #politics channel available
-- Request access by DMing channel moderator (see placeholder channel #politics)
-- General channels: keep politics relevant to our work (tech policy, privacy laws)
-- Admins may intervene if discussions become disruptive
+- To protect everyone's right to speak freely without intimidation by oppressive governments, the politics channel has been made private.
+- Please join #politics and read instructions to join the private politics channel.
+- Request access by sending a DM to a channel moderator.
+- For all other channels: keep politics to a minimum, and strictly relevant to our work (tech policy, privacy laws)
+- If discussions become uncivil or disruptive, the Slack admins may intervene.
 
 **Religion**
 
-- Respect all beliefs and non-beliefs
-- Keep discussions civil
-- Don't proselytize
-- Admins may intervene if discussions become contentious
+- Respect all beliefs and non-beliefs.
+- Keep discussions civil.
+- Don't proselytize (i.e.: missionary work, actively persuading people to follow your religion).
+- As with politics, if discussions become contentious, the Slack admins may intervene.
 
 **Controversial Topics**
 
 - Admins determine what constitutes a controversial topic based on community impact and whether discussions become disruptive
-- Examples include: contentious social issues, divisive current events, sensitive workplace situations
+- Examples include: contentious social issues, divisive current events, sensitive workplace situations.
 - Use content warnings for potentially triggering topics (format: "[CW: topic]" at the start of your message)
-- Consider whether Slack is the right venue
-- Move to DMs if requested
-- Stop if asked by Admins
+- Consider whether Slack is the right venue.
+- Move to DMs if requested.
+- Stop if asked by an admin.
 
-### 8.3 Not Appropriate for This Workspace
+### [8.3 Not Appropriate for This Workspace](#83-not-appropriate-for-this-workspace)
 
-- Cryptocurrency promotion or investment advice
-- Multi-level marketing (MLM)
-- Political activism unrelated to tech
-- Personal grievances with employers (use discretion)
-- Legal advice (we're not lawyers)
-- Medical advice (we're not doctors)
+- Cryptocurrency promotion or investment advice.
+- Multi-level marketing (MLM).
+- Personal grievances with employers (use discretion).
+- Legal advice (we're not lawyers).
+- Medical advice (we're not doctors).
 
 ## [9. Bots and Automation](#9-bots-and-automation)
 
-Only MAF-approved bots are enabled in the workspace. User bots and custom integrations are not permitted.
+Some bots and apps are enabled in the workspace.  Applications and integrations cannot be added or connected to this Slack without permissions from the Slack admins.
 
 **Slash Commands and Integrations**
 
-- Use built-in Slack commands appropriately
-- Report malfunctioning bots to Admins
+- Use built-in Slack commands appropriately.
+- Please report any malfunctions to the Slack admins.
 
-## [10. Data and Privacy](#10-data-and-privacy)
+## [10. Data Privacy](#10-data-privacy)
 
-### 10.1 Your Data
+### [10.1 Your Data](#101-your-data)
 
-- The Mac Admins Slack is on a Business+ plan with full message and file retention
-- Everything you post is retained permanently in Slack's systems
-- Users can request deletion of individual messages, but there is no bulk data deletion or "right to be forgotten" option
+- The MacAdmins Slack is on a Business+ plan with full message and file retention.
+- Everything you post is retained permanently in Slack's systems.
+- Users can request deletion of individual messages, but there is no bulk data deletion or "right to be forgotten" option.
 - Don't post sensitive information (passwords, keys, etc.)
-- Assume anything posted may become public
-- Be thoughtful about what you post - message history is permanent
+- Assume anything posted may become public some day.
+- Be thoughtful about what you post; message history is permanent.
 
-### 10.2 Others' Data
+### [10.2 Others' Data](#102-others-data)
 
-- Don't collect member data without permission
-- Don't scrape the workspace
-- Don't share member information outside Slack
-- Don't use automated tools to download, export, or archive workspace content
-- Don't train AI models or build datasets using workspace content
-- Don't create external databases or archives of community conversations
-- Report data harvesting to Admins
+- DO NOT collect member data without permission.
+- DO NOT scrape the workspace.
+- DO NOT share member information outside Slack.
+- DO NOT use automated tools to download, export, or archive workspace content.
+- DO NOT train AI/LLM models or build datasets using workspace content.
+- DO NOT create external databases or archives of community conversations.
+- DO report data harvesting to Admins.
 
-### 10.3 Admin Access
+### [10.3 Admin Access](#103-admin-access)
 
-- Admins can access all channels and DMs if needed for investigations
-- Admins follow strict confidentiality policies
-- Data access is logged and auditable
-- Admin Runbooks available for admins
+- Admins can access all channels (public and private) and all DMs if needed for investigations.
+- Admins follow strict confidentiality policies.
+- Data access is logged and auditable.
+- The Admin Runbook is available to admins only.
 
 ## [11. Recognition and Credit](#11-recognition-and-credit)
 
 **Giving Credit**
 
-- Credit others' work and ideas
-- Link to original sources
-- Tag people when sharing their content
-- Say thank you
+- Please credit others' work and ideas.
+- Please link to original source(s) where possible.
+- Please tag @usernames when sharing their content.
+- Always say thank you and express your gratitude for their efforts.
 
 **Receiving Credit**
 
-- Accept credit gracefully
-- Acknowledge collaborators
-- Share the spotlight
+- Accept credit gracefully.
+- Acknowledge collaborators.
+- Share the spotlight.
 
 ## [12. When Things Go Wrong](#12-when-things-go-wrong)
 
-### 12.1 If You Made a Mistake
+### [12.1 If You Made a Mistake](#121-if-you-made-a-mistake)
 
-1. Acknowledge it
-2. Apologize if appropriate
-3. Learn from it
-4. Move forward
+1. Acknowledge the mistake.
+2. Apologize for hurt feelings.
+3. Learn from the experience.
+4. Move forward.
 
-### 12.2 If You're Affected by Someone Else's Behavior
+### [12.2 If You're Affected by Someone Else's Behavior](#122-if-youre-affected-by-someone-elses-behavior)
 
 1. Consider addressing it directly (if safe and comfortable)
 2. [Report to Admins](./Code_of_Conduct.md#6-reporting) if it violates the CoC
 3. Use the mute or block features if needed
 4. Know that Admins take reports seriously
 
-### 12.3 If You're Contacted by an Admin
+### [12.3 If You're Contacted by an Admin](#123-if-youre-contacted-by-an-admin)
 
-- Respond promptly and respectfully
-- Provide your perspective
-- Ask questions if you don't understand
-- Accept the outcome gracefully (or use the [appeals process](./Code_of_Conduct.md#8-appeals))
+- Respond promptly and respectfully.
+- Provide your perspective.
+- Ask questions if you don't understand.
+- Accept any disciplinary actions gracefully.
+- When necessary, use the [appeals process](./Code_of_Conduct.md#8-appeals).
 
 ## [13. Resources](#13-resources)
 
-- [Code of Conduct](./Code_of_Conduct.md) - What's not acceptable
-- [Vendor Policy](./Vendor_Policy.md) - Guidelines for vendors
-- [Admin Team](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md) - How to contact Admins
+- [Code of Conduct](./Code_of_Conduct.md): This document outlines what is not acceptable on the MacAdmins Slack.
+- [Vendor Policy](./Vendor_Policy.md) - This document contains guidelines for Vendors.
+- [Admin Team](https://github.com/macadminsdotorg/slack-assets/blob/master/Admins.md): this is how to contact the admins.
 
 ## [14. Getting Help](#14-getting-help)
-
-**Technical Help**
-
-- Post in relevant technical channels
-- Search history first
-- Provide context and details
 
 **Admin Help**
 
@@ -444,18 +496,18 @@ Only MAF-approved bots are enabled in the workspace. User bots and custom integr
 - Use @admins for urgent matters
 - Email <admin@macadmins.org>
 
-**MAF Questions**
+**Questions about the MacAdmins Foundation**
 
-- #macadminsfoundation channel
-- <board@macadmins.org>
+- The channel is #macadminsfoundation
+- Email address for the board is: <board@macadmins.org>
 
 ## [15. Contributing to These Guidelines](#15-contributing-to-these-guidelines)
 
 These guidelines evolve based on community needs. To suggest improvements:
 
-1. Open an issue in the [codeofconduct repository](https://github.com/macadminsdotorg/codeofconduct)
-2. Discuss in #macadminsfoundation
-3. Contact an Admin or MAF Board member
+1. Open an issue in the [codeofconduct repository](https://github.com/macadminsdotorg/codeofconduct).
+3. Discuss in #macadminsfoundation.
+4. Contact an Admin or MAF Board member
 
 ## [16. Final Thoughts](#16-final-thoughts)
 

--- a/Community_Guidelines.md
+++ b/Community_Guidelines.md
@@ -53,7 +53,7 @@
 
 ## [1. Purpose](#1-purpose)
 
-The Community Guidelines are a **supplement** to the [Code of Conduct](./Code_of_Conduct.md), and contain practical guidance to get the most out of your membership in the MacAdmins Slack.  Think of this document like a book of manners, or an etiquette guide for this networked space ("netiquette").
+The Community Guidelines are a **supplement** to the [Code of Conduct](./Code_of_Conduct.md), and contain practical guidance to get the most out of your membership in the MacAdmins Slack.  Think of this document like a book of manners, or an etiquette guide for this networked space.
 
 ## [2. Getting Started](#2-getting-started)
 


### PR DESCRIPTION
This is the beginning of my effort to expand upon the shorthand writing style of the community guidelines.

I felt that some key policy and etiquette details were missing, some clarification was needed in places, and I split up the description of the jobs-board and jobs-chat channels.

I completed this much on my phone in 45 minutes, but editing on GitHub is a pain in the ass on a mobile phone due to idiosyncrasies and/or bugs with GitHub where tapping the backspace button too rapidly ends up deleting more than I wanted to.

I will finish revising this on a computer this afternoon and over the weekend.