### PR TITLE
Add Section 7.3: Cumulative Conduct

### DIFF
--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -215,7 +215,7 @@ When assessing whether a pattern of behaviour warrants action, Admins may consid
 
 Membership is a privilege, not a right. Where Admins collectively determine that a member's continued presence is incompatible with the kind of community described in the Code of Conduct, regardless of whether a single definitive violation can be identified — they may take action up to and including permanent removal.
 
-Account reactivation following voluntary deactivation or prior removal is at the discretion of the Administrators and is not guaranteed. Where a pattern of disruptive behaviour has been established, reactivation may be declined.
+Account reactivation following voluntary deactivation or prior removal is at the discretion of the Admins and is not guaranteed. Where a pattern of disruptive behaviour has been established, reactivation may be declined.
 
 ## [8. Appeals](#8-appeals)
 

--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -19,6 +19,7 @@
 - [7. Enforcement](#7-enforcement)
   - [7.1 Violation Levels](#71-violation-levels)
   - [7.2 Progressive Discipline](#72-progressive-discipline)
+  - [7.3 Cumulative Conduct](#73-cumulative-conduct)
 - [8. Appeals](#8-appeals)
   - [8.1 Appealing Enforcement Actions](#81-appealing-enforcement-actions)
   - [8.2 Reporting Admin Misconduct](#82-reporting-admin-misconduct)
@@ -200,6 +201,21 @@ For repeated violations:
 3. Third offense: Temporary or permanent ban
 
 **Note:** Severe violations skip progressive discipline and result in immediate permanent ban.
+
+### 7.3 Cumulative Conduct
+
+While individual incidents are assessed on their own merits, the Administrators also consider the cumulative pattern of a member's conduct over time. A series of behaviours that each fall below the threshold of a clear CoC violation may, taken together, constitute a pattern that is incompatible with the spirit of this community.
+
+When assessing whether a pattern of behaviour warrants action, Administrators may consider:
+
+- Repeated conduct that disrupts, antagonises, or frustrates other members, even where no single instance is an obvious violation
+- A history of skirting the boundaries of this CoC without technically breaching it
+- Voluntarily deactivating and subsequently seeking reactivation of a Slack account, particularly where this has followed incidents of disruptive behaviour
+- Contacting Administrators or community members through channels external to the Mac Admins Slack (such as LinkedIn, email, or other platforms) in relation to disputes, moderation decisions, or requests for account reinstatement
+
+Membership is a privilege, not a right. Where Administrators collectively determine that a member's continued presence is incompatible with the kind of community described in this CoC — regardless of whether a single definitive violation can be identified — they may take action up to and including permanent removal.
+
+Account reactivation following voluntary deactivation or prior removal is at the discretion of the Administrators and is not guaranteed. Where a pattern of disruptive behaviour has been established, reactivation may be declined.
 
 ## [8. Appeals](#8-appeals)
 

--- a/Code_of_Conduct.md
+++ b/Code_of_Conduct.md
@@ -204,16 +204,16 @@ For repeated violations:
 
 ### 7.3 Cumulative Conduct
 
-While individual incidents are assessed on their own merits, the Administrators also consider the cumulative pattern of a member's conduct over time. A series of behaviours that each fall below the threshold of a clear CoC violation may, taken together, constitute a pattern that is incompatible with the spirit of this community.
+While individual incidents are assessed on their own merits, the Admins also consider the cumulative pattern of a member's conduct over time. A series of behaviours that each fall below the threshold of a clear CoC violation may, taken together, constitute a pattern that is incompatible with the spirit of the community.
 
-When assessing whether a pattern of behaviour warrants action, Administrators may consider:
+When assessing whether a pattern of behaviour warrants action, Admins may consider:
 
 - Repeated conduct that disrupts, antagonises, or frustrates other members, even where no single instance is an obvious violation
 - A history of skirting the boundaries of this CoC without technically breaching it
 - Voluntarily deactivating and subsequently seeking reactivation of a Slack account, particularly where this has followed incidents of disruptive behaviour
-- Contacting Administrators or community members through channels external to the Mac Admins Slack (such as LinkedIn, email, or other platforms) in relation to disputes, moderation decisions, or requests for account reinstatement
+- Contacting Admins or community members through channels external to the Mac Admins Slack (such as LinkedIn, email, or other platforms) in relation to disputes, moderation decisions, or requests for account reinstatement
 
-Membership is a privilege, not a right. Where Administrators collectively determine that a member's continued presence is incompatible with the kind of community described in this CoC — regardless of whether a single definitive violation can be identified — they may take action up to and including permanent removal.
+Membership is a privilege, not a right. Where Admins collectively determine that a member's continued presence is incompatible with the kind of community described in the Code of Conduct, regardless of whether a single definitive violation can be identified — they may take action up to and including permanent removal.
 
 Account reactivation following voluntary deactivation or prior removal is at the discretion of the Administrators and is not guaranteed. Where a pattern of disruptive behaviour has been established, reactivation may be declined.
 


### PR DESCRIPTION
## Summary

- Adds new **Section 7.3 Cumulative Conduct** to the Code of Conduct under Enforcement, addressing cases where no single incident constitutes a clear violation but a cumulative pattern of behaviour is incompatible with community standards
- Establishes criteria Admins may consider when assessing patterns: repeated disruptive conduct, boundary-skirting, voluntary deactivation/reactivation cycles, and out-of-band contact regarding moderation decisions
- Clarifies that membership is a privilege, not a right, and that account reactivation is at Admin discretion

## Test plan

- [x] Review rendered markdown for correct formatting and heading levels
- [x] Verify Table of Contents entry for 7.3 links correctly
- [x] Confirm section numbering remains consistent with surrounding sections
- [ ] Review language for alignment with existing CoC tone and terminology